### PR TITLE
Windows support

### DIFF
--- a/commands/hijack.go
+++ b/commands/hijack.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package commands
 
 import (

--- a/commands/hijack_windows.go
+++ b/commands/hijack_windows.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build windows
 
 package commands
 

--- a/commands/hijack_windows.go
+++ b/commands/hijack_windows.go
@@ -11,5 +11,5 @@ import (
 
 func Hijack(c *cli.Context) {
 	log.Fatalln("Command not supported on Windows!")
-	os.Exit(0)
+	os.Exit(1)
 }

--- a/commands/hijack_windows.go
+++ b/commands/hijack_windows.go
@@ -1,0 +1,15 @@
+// +build !windows
+
+package commands
+
+import (
+	"log"
+	"os"
+
+	"github.com/codegangsta/cli"
+)
+
+func Hijack(c *cli.Context) {
+	log.Fatalln("Command not supported on Windows!")
+	os.Exit(0)
+}


### PR DESCRIPTION
I wanted to open this PR up but it still needs build/tested on Windows before it's ready to be merged.

Right now the approach is just to turn `hijack`/`intercept` into a no-op and return a non zero exit code with a warning to the user. It is believed that this is the only part of the code that fails to compile on Windows.