### PR TITLE
Specify that you need to be in fly dir to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A good place to start learning about Concourse is its [BOSH release](https://git
 
 ## Building
 
-Fly is built using [Go](http://golang.org/). Building and testing fly is most easily done from a checkout of [concourse](https://github.com/concourse/concourse). 
+Fly is built using [Go](http://golang.org/). Building and testing fly is most easily done from a checkout of [concourse](https://github.com/concourse/concourse).
 
 1. Check out concourse and update submodules:
 
@@ -22,6 +22,7 @@ directory to setup your environment.
 3. You can now build the the fly binary with go build:
 
   ```bash
+  cd src/github.com/concourse/fly
   go build
   ```
 


### PR DESCRIPTION
Just makes the build process a little clearer.