### PR TITLE
Readme: Installing Fly for other projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,23 @@ directory to setup your environment.
   go get github.com/onsi/ginkgo/ginkgo
   ginkgo -r
   ```
+
+## Installing from the Concourse UI for Project Development
+
+Fly is available for download in the lower right-hand corner of the concourse UI.
+
+1. Click the button corresponding to your OS
+
+2. Move the downloaded file onto your PATH
+
+  ```bash
+  mv ~/Downloads/fly /usr/bin
+  ```
+
+3. Make the fly file executable
+
+  ```bash
+  chmod +x /usr/bin/fly
+  ```
+
+4. Confirm availability with `which fly`


### PR DESCRIPTION
This probably should be in the main documentation too.

We're needing to provide this documentation because installing fly is necessary for our builds, but it's kinda a catch-22 (want to stand up concourse and then use fly, but can't install fly until we've stood up concourse).

Is there an easier way to automate the installation of fly?