### PR TITLE
Extract .flyrc code from commands package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ _testmain.go
 
 # Archives
 *.tgz
+
+# Ignore Generated Binary
+fly

--- a/commands/checklist.go
+++ b/commands/checklist.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/concourse/atc"
+	"github.com/concourse/fly/rc"
 )
 
 type ChecklistCommand struct {
@@ -30,7 +31,12 @@ func init() {
 }
 
 func (command *ChecklistCommand) Execute([]string) error {
-	rawTarget := returnTarget(globalOptions.Target)
+	target, err := rc.SelectTarget(globalOptions.Target)
+	if err != nil {
+		log.Fatalln(err)
+		return nil
+	}
+
 	insecure := globalOptions.Insecure
 	pipelineName := command.Pipeline
 
@@ -38,9 +44,9 @@ func (command *ChecklistCommand) Execute([]string) error {
 		pipelineName = atc.DefaultPipelineName
 	}
 
-	atcRequester := newAtcRequester(rawTarget, insecure)
+	atcRequester := newAtcRequester(target.URL(), insecure)
 
-	printCheckfile(pipelineName, getConfig(pipelineName, atcRequester), newTarget(rawTarget))
+	printCheckfile(pipelineName, getConfig(pipelineName, atcRequester), newTarget(target.URL()))
 
 	return nil
 }

--- a/commands/destroy_pipeline.go
+++ b/commands/destroy_pipeline.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/concourse/atc"
+	"github.com/concourse/fly/rc"
 	"github.com/tedsuo/rata"
 )
 
@@ -31,7 +32,12 @@ func init() {
 }
 
 func (command *DestroyPipelineCommand) Execute(args []string) error {
-	target := returnTarget(globalOptions.Target)
+	target, err := rc.SelectTarget(globalOptions.Target)
+	if err != nil {
+		log.Fatalln(err)
+		return nil
+	}
+
 	insecure := globalOptions.Insecure
 
 	pipelineName := command.Pipeline
@@ -44,7 +50,7 @@ func (command *DestroyPipelineCommand) Execute(args []string) error {
 		os.Exit(1)
 	}
 
-	atcRequester := newAtcRequester(target, insecure)
+	atcRequester := newAtcRequester(target.URL(), insecure)
 
 	deletePipeline, err := atcRequester.CreateRequest(
 		atc.DeletePipeline,

--- a/commands/execute.go
+++ b/commands/execute.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"os/exec"
@@ -17,6 +18,7 @@ import (
 	"github.com/concourse/atc"
 	"github.com/concourse/fly/config"
 	"github.com/concourse/fly/eventstream"
+	"github.com/concourse/fly/rc"
 	"github.com/tedsuo/rata"
 	"github.com/vito/go-sse/sse"
 )
@@ -46,12 +48,17 @@ func init() {
 }
 
 func (command *ExecuteCommand) Execute(args []string) error {
-	target := returnTarget(globalOptions.Target)
+	target, err := rc.SelectTarget(globalOptions.Target)
+	if err != nil {
+		log.Fatalln(err)
+		return nil
+	}
+
 	insecure := globalOptions.Insecure
 	taskConfigFile := command.TaskConfig
 	excludeIgnored := command.ExcludeIgnored
 
-	atcRequester := newAtcRequester(target, insecure)
+	atcRequester := newAtcRequester(target.URL(), insecure)
 
 	taskConfig := config.LoadTaskConfig(string(taskConfigFile), args)
 

--- a/commands/get_config.go
+++ b/commands/get_config.go
@@ -1,7 +1,10 @@
 package commands
 
 import (
+	"log"
+
 	atcroutes "github.com/concourse/atc/web/routes"
+	"github.com/concourse/fly/rc"
 	"github.com/tedsuo/rata"
 )
 
@@ -27,13 +30,18 @@ func init() {
 }
 
 func (command *GetConfigCommand) Execute(args []string) error {
-	target := returnTarget(globalOptions.Target)
+	target, err := rc.SelectTarget(globalOptions.Target)
+	if err != nil {
+		log.Fatalln(err)
+		return nil
+	}
+
 	insecure := globalOptions.Insecure
 	asJSON := command.JSON
 	pipelineName := command.Pipeline
 
-	apiRequester := newAtcRequester(target, insecure)
-	webRequestGenerator := rata.NewRequestGenerator(target, atcroutes.Routes)
+	apiRequester := newAtcRequester(target.URL(), insecure)
+	webRequestGenerator := rata.NewRequestGenerator(target.URL(), atcroutes.Routes)
 
 	atcConfig := ATCConfig{
 		pipelineName:        pipelineName,

--- a/commands/helpers.go
+++ b/commands/helpers.go
@@ -6,15 +6,10 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-	"net/url"
 	"os"
-	"path/filepath"
-	"runtime"
-	"strings"
 
 	"github.com/concourse/atc"
 	"github.com/tedsuo/rata"
-	"gopkg.in/yaml.v2"
 )
 
 func getConfig(pipelineName string, atcRequester *atcRequester) atc.Config {
@@ -46,51 +41,6 @@ func getConfig(pipelineName string, atcRequester *atcRequester) atc.Config {
 	}
 
 	return config
-}
-
-func returnTarget(startingTarget string) string {
-	target := lookupURLFromName(startingTarget)
-	if target == "" {
-		target = startingTarget
-	}
-
-	return strings.TrimRight(target, "/")
-}
-
-func lookupURLFromName(targetName string) string {
-	flyrc := filepath.Join(userHomeDir(), ".flyrc")
-
-	currentTargetsBytes, err := ioutil.ReadFile(flyrc)
-	if err != nil {
-		return ""
-	}
-
-	var current *TargetDetailsYAML
-	err = yaml.Unmarshal(currentTargetsBytes, &current)
-	if err != nil {
-		return ""
-	}
-
-	if details, ok := current.Targets[targetName]; ok {
-		userInfo := url.UserPassword(details.Username, details.Password)
-		targetURL, _ := url.Parse(details.API)
-		targetURL.User = userInfo
-
-		return targetURL.String()
-	}
-
-	return ""
-}
-
-func userHomeDir() string {
-	if runtime.GOOS == "windows" {
-		home := os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
-		if home == "" {
-			home = os.Getenv("USERPROFILE")
-		}
-		return home
-	}
-	return os.Getenv("HOME")
 }
 
 func handleBadResponse(process string, resp *http.Response) {

--- a/commands/set_config.go
+++ b/commands/set_config.go
@@ -2,9 +2,11 @@ package commands
 
 import (
 	"fmt"
+	"log"
 	"os"
 
 	atcroutes "github.com/concourse/atc/web/routes"
+	"github.com/concourse/fly/rc"
 	"github.com/concourse/fly/template"
 	"github.com/tedsuo/rata"
 )
@@ -36,7 +38,12 @@ func init() {
 func (command *SetConfigCommand) Execute(args []string) error {
 	var paused PipelineAction
 
-	target := returnTarget(globalOptions.Target)
+	target, err := rc.SelectTarget(globalOptions.Target)
+	if err != nil {
+		log.Fatalln(err)
+		return nil
+	}
+
 	insecure := globalOptions.Insecure
 	configPath := command.Config
 	templateVariablesFiles := command.VarsFrom
@@ -59,8 +66,8 @@ func (command *SetConfigCommand) Execute(args []string) error {
 		paused = DoNotChangePipeline
 	}
 
-	apiRequester := newAtcRequester(target, insecure)
-	webRequestGenerator := rata.NewRequestGenerator(target, atcroutes.Routes)
+	apiRequester := newAtcRequester(target.URL(), insecure)
+	webRequestGenerator := rata.NewRequestGenerator(target.URL(), atcroutes.Routes)
 
 	atcConfig := ATCConfig{
 		pipelineName:        pipelineName,

--- a/commands/sync.go
+++ b/commands/sync.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"crypto/tls"
 	"fmt"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -12,6 +13,7 @@ import (
 	"github.com/tedsuo/rata"
 
 	"github.com/concourse/atc"
+	"github.com/concourse/fly/rc"
 )
 
 type SyncCommand struct{}
@@ -33,9 +35,14 @@ func init() {
 }
 
 func (command *SyncCommand) Execute(args []string) error {
-	target := returnTarget(globalOptions.Target)
+	target, err := rc.SelectTarget(globalOptions.Target)
+	if err != nil {
+		log.Fatalln(err)
+		return nil
+	}
+
 	insecure := globalOptions.Insecure
-	reqGenerator := rata.NewRequestGenerator(target, atc.Routes)
+	reqGenerator := rata.NewRequestGenerator(target.URL(), atc.Routes)
 
 	request, err := reqGenerator.CreateRequest(
 		atc.DownloadCLI, rata.Params{}, nil,

--- a/commands/watch.go
+++ b/commands/watch.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/concourse/atc"
 	"github.com/concourse/fly/eventstream"
+	"github.com/concourse/fly/rc"
 	"github.com/tedsuo/rata"
 	"github.com/vito/go-sse/sse"
 )
@@ -34,10 +35,15 @@ func init() {
 	watch.Aliases = []string{"w"}
 }
 func (command *WatchCommand) Execute(args []string) error {
-	target := returnTarget(globalOptions.Target)
+	target, err := rc.SelectTarget(globalOptions.Target)
+	if err != nil {
+		log.Fatalln(err)
+		return nil
+	}
+
 	insecure := globalOptions.Insecure
 
-	atcRequester := newAtcRequester(target, insecure)
+	atcRequester := newAtcRequester(target.URL(), insecure)
 
 	build := getBuild(atcRequester.httpClient, atcRequester.RequestGenerator, command.Job.JobName, command.Build, command.Job.PipelineName)
 

--- a/integration/save_test.go
+++ b/integration/save_test.go
@@ -132,6 +132,19 @@ targets:
 			<-sess.Exited
 			Expect(sess.ExitCode()).To(Equal(0))
 		})
+
+		It("should error when saving a target who's name begins with 'http'", func() {
+			flyCmd := exec.Command(flyPath,
+				"save-target",
+				"--api", targetURL,
+				"--name", "http://my-test-target",
+			)
+
+			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(sess).Should(gexec.Exit(1))
+			Expect(sess.Err.Contents()).To(MatchRegexp("target name.*http"))
+		})
 	})
 
 	Context("when a .flyrc exists", func() {

--- a/rc/targets.go
+++ b/rc/targets.go
@@ -1,0 +1,90 @@
+package rc
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"gopkg.in/yaml.v2"
+)
+
+type targetProps struct {
+	API      string `yaml:"api"`
+	Username string
+	Password string
+	Cert     string
+}
+
+type targetDetailsYAML struct {
+	Targets map[string]targetProps
+}
+
+func NewTarget(api, username, password, cert string) targetProps {
+	return targetProps{
+		API:      api,
+		Username: username,
+		Password: password,
+		Cert:     cert,
+	}
+}
+
+func CreateOrUpdateTargets(targetName string, targetInfo targetProps) error {
+	flyrc := filepath.Join(userHomeDir(), ".flyrc")
+	flyTargets, err := loadTargets(flyrc)
+	if err != nil {
+		return err
+	}
+
+	flyTargets.Targets[targetName] = targetInfo
+
+	return writeTargets(flyrc, flyTargets)
+}
+
+func userHomeDir() string {
+	if runtime.GOOS == "windows" {
+		home := os.Getenv("HOMEDRIVE") + os.Getenv("HOMEPATH")
+		if home == "" {
+			home = os.Getenv("USERPROFILE")
+		}
+		return home
+	}
+	return os.Getenv("HOME")
+}
+
+func loadTargets(configFileLocation string) (*targetDetailsYAML, error) {
+	var flyTargets *targetDetailsYAML
+
+	if _, err := os.Stat(configFileLocation); err == nil {
+		flyTargetsBytes, err := ioutil.ReadFile(configFileLocation)
+		if err != nil {
+			return nil, fmt.Errorf("could not read %s", configFileLocation)
+		}
+
+		err = yaml.Unmarshal(flyTargetsBytes, &flyTargets)
+		if err != nil {
+			return nil, fmt.Errorf("could not unmarshal %s", configFileLocation)
+		}
+	}
+
+	if flyTargets == nil {
+		return &targetDetailsYAML{Targets: map[string]targetProps{}}, nil
+	}
+
+	return flyTargets, nil
+}
+
+func writeTargets(configFileLocation string, targetsToWrite *targetDetailsYAML) error {
+	yamlBytes, err := yaml.Marshal(targetsToWrite)
+	if err != nil {
+		return fmt.Errorf("could not marshal %s", configFileLocation)
+	}
+
+	err = ioutil.WriteFile(configFileLocation, yamlBytes, os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("could not write %s", configFileLocation)
+	}
+
+	return nil
+}

--- a/rc/targets.go
+++ b/rc/targets.go
@@ -1,6 +1,7 @@
 package rc
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/url"
@@ -47,6 +48,10 @@ func CreateOrUpdateTargets(targetName string, targetInfo targetProps) error {
 	flyTargets, err := loadTargets(flyrc)
 	if err != nil {
 		return err
+	}
+
+	if isURL(targetName) {
+		return errors.New("The target name cannot begin with http:// or https://.")
 	}
 
 	flyTargets.Targets[targetName] = targetInfo


### PR DESCRIPTION
Unifying how all the commands get their target properties seems like a good first step towards making an ATC client.

Pulled in creating/updating the `.flyrc` into the same package to centralize all the code.

Also fixed an issue that came up when the `.flyrc` was blank and you tried to `save-target` the fly command would panic in a horrible way.