### PR TITLE
Fix nil pointer dereference in upload error handling

### DIFF
--- a/commands/internal/executehelpers/uploads.go
+++ b/commands/internal/executehelpers/uploads.go
@@ -50,6 +50,7 @@ func Upload(input Input, excludeIgnored bool, atcRequester *deprecated.AtcReques
 	response, err := atcRequester.HttpClient.Do(uploadBits)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "upload request failed:", err)
+		return
 	}
 
 	defer response.Body.Close()


### PR DESCRIPTION
When running `fly execute` earlier, we hit the error below.  Appears to be a nil pointer deference.

```
upload request failed: Put https://mega.ci.cf-app.com/api/v1/pipes/e5e3a866-cfbb-4d66-4e51-e071a02751eb: EOF
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x12bedd]

goroutine 53 [running]:
github.com/concourse/fly/commands/internal/executehelpers.Upload(0x7fff5fbff8f2, 0x13, 0x7fff5fbff906, 0x1, 0x820c68960, 0x24, 0x0, 0x0, 0x0, 0x0, ...)
	/var/vcap/packages/fly/src/github.com/concourse/fly/commands/internal/executehelpers/uploads.go:55 +0xb0d
github.com/concourse/fly/commands.(*ExecuteCommand).Execute.func1(0x8208d4d80, 0x5, 0x8, 0x882097c000, 0x8208b6ed0, 0x820911a40)
	/var/vcap/packages/fly/src/github.com/concourse/fly/commands/execute.go:93 +0xf1
created by github.com/concourse/fly/commands.(*ExecuteCommand).Execute
	/var/vcap/packages/fly/src/github.com/concourse/fly/commands/execute.go:97 +0xb91

goroutine 1 [chan receive]:
github.com/concourse/fly/commands.(*ExecuteCommand).Execute(0x727f58, 0x8208720f0, 0x0, 0xf, 0x0, 0x0)
	/var/vcap/packages/fly/src/github.com/concourse/fly/commands/execute.go:123 +0x1162
github.com/jessevdk/go-flags.(*Parser).ParseArgs(0x8207e0b90, 0x8207d4110, 0xf, 0xf, 0x0, 0x0, 0x0, 0x0, 0x0)
	/var/vcap/packages/fly/src/github.com/jessevdk/go-flags/parser.go:278 +0x8ed
github.com/jessevdk/go-flags.(*Parser).Parse(0x8207e0b90, 0x0, 0x0, 0x0, 0x0, 0x0)
	/var/vcap/packages/fly/src/github.com/jessevdk/go-flags/parser.go:154 +0x9b
main.main()
	/var/vcap/packages/fly/src/github.com/concourse/fly/main.go:14 +0x62

goroutine 5 [syscall, 3 minutes]:
os/signal.loop()
	/var/vcap/data/packages/golang/08f1cb1a11d32468882fc07a0d5b33fd735ddda4.1-86faa714b302e875344b9eb71af47758f6d050e1/src/os/signal/signal_unix.go:22 +0x18
created by os/signal.init.1
	/var/vcap/data/packages/golang/08f1cb1a11d32468882fc07a0d5b33fd735ddda4.1-86faa714b302e875344b9eb71af47758f6d050e1/src/os/signal/signal_unix.go:28 +0x37

goroutine 51 [chan receive, 3 minutes]:
github.com/concourse/fly/commands.abortOnSignal(0x8820980f18, 0x8208b6ec0, 0x8209118c0, 0x4c4, 0x820c94d00, 0x3, 0x820c94d10, 0x7, 0x0, 0x0, ...)
	/var/vcap/packages/fly/src/github.com/concourse/fly/commands/execute.go:141 +0x45
created by github.com/concourse/fly/commands.(*ExecuteCommand).Execute
	/var/vcap/packages/fly/src/github.com/concourse/fly/commands/execute.go:85 +0x97e

goroutine 52 [select, 3 minutes, locked to thread]:
runtime.gopark(0x5af5f8, 0x8207f5728, 0x4e5458, 0x6, 0x18, 0x2)
	/var/vcap/data/packages/golang/08f1cb1a11d32468882fc07a0d5b33fd735ddda4.1-86faa714b302e875344b9eb71af47758f6d050e1/src/runtime/proc.go:185 +0x163
runtime.selectgoImpl(0x8207f5728, 0x0, 0x18)
	/var/vcap/data/packages/golang/08f1cb1a11d32468882fc07a0d5b33fd735ddda4.1-86faa714b302e875344b9eb71af47758f6d050e1/src/runtime/select.go:392 +0xa64
runtime.selectgo(0x8207f5728)
	/var/vcap/data/packages/golang/08f1cb1a11d32468882fc07a0d5b33fd735ddda4.1-86faa714b302e875344b9eb71af47758f6d050e1/src/runtime/select.go:212 +0x12
runtime.ensureSigM.func1()
	/var/vcap/data/packages/golang/08f1cb1a11d32468882fc07a0d5b33fd735ddda4.1-86faa714b302e875344b9eb71af47758f6d050e1/src/runtime/signal1_unix.go:227 +0x323
runtime.goexit()
	/var/vcap/data/packages/golang/08f1cb1a11d32468882fc07a0d5b33fd735ddda4.1-86faa714b302e875344b9eb71af47758f6d050e1/src/runtime/asm_amd64.s:1696 +0x1
```

cc: @rosenhouse