### PR TITLE
Adding create-job-build as a command option

### DIFF
--- a/commands/fly.go
+++ b/commands/fly.go
@@ -25,6 +25,8 @@ type FlyCommand struct {
 	PausePipeline   PausePipelineCommand   `command:"pause-pipeline"   alias:"pp" description:"Pause a pipeline"`
 	UnpausePipeline UnpausePipelineCommand `command:"unpause-pipeline" alias:"up" description:"Un-pause a pipeline"`
 
+	TriggerJob TriggerJobCommand `command:"trigger-job"   alias:"tj" description:"Start a job in a pipeline"`
+
 	Builds BuildsCommand `command:"builds" alias:"bs" description:"List builds data"`
 
 	Volumes VolumesCommand `command:"volumes" alias:"vs" description:"List the active volumes"`

--- a/commands/trigger_job.go
+++ b/commands/trigger_job.go
@@ -1,0 +1,29 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/concourse/fly/commands/internal/displayhelpers"
+	"github.com/concourse/fly/commands/internal/flaghelpers"
+	"github.com/concourse/fly/rc"
+)
+
+type TriggerJobCommand struct {
+	Job flaghelpers.JobFlag `short:"j" long:"job" required:"true" value-name:"PIPELINE/JOB"   description:"Name of a job to start"`
+}
+
+func (command *TriggerJobCommand) Execute(args []string) error {
+	pipelineName, jobName := command.Job.PipelineName, command.Job.JobName
+
+	client, err := rc.TargetClient(Fly.Target)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.CreateJobBuild(pipelineName, jobName)
+	if err != nil {
+		displayhelpers.FailWithErrorf("pipeline/job '%s/%s' not found\n", err, pipelineName, jobName)
+	}
+	fmt.Printf("started '%s/%s'\n", pipelineName, jobName)
+	return nil
+}

--- a/integration/trigger_job_test.go
+++ b/integration/trigger_job_test.go
@@ -1,0 +1,94 @@
+package integration_test
+
+import (
+	"net/http"
+	"os/exec"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/concourse/atc"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+	"github.com/onsi/gomega/ghttp"
+	"github.com/tedsuo/rata"
+)
+
+var _ = Describe("Fly CLI", func() {
+	Describe("trigger-job", func() {
+		Context("when the pipeline and job name are specified", func() {
+			var (
+				path string
+				err  error
+			)
+			BeforeEach(func() {
+				path, err = atc.Routes.CreatePathForRoute(atc.CreateJobBuild, rata.Params{"pipeline_name": "awesome-pipeline", "job_name": "awesome-job"})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			Context("when the pipeline and job exists", func() {
+				BeforeEach(func() {
+					atcServer.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("POST", path),
+							ghttp.RespondWithJSONEncoded(http.StatusOK, atc.Build{}),
+						),
+					)
+				})
+
+				It("starts the build", func() {
+					reqsBefore := len(atcServer.ReceivedRequests())
+					flyCmd := exec.Command(flyPath, "-t", targetName, "trigger-job", "-j", "awesome-pipeline/awesome-job")
+
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(sess).Should(gbytes.Say(`started 'awesome-pipeline/awesome-job'`))
+
+					<-sess.Exited
+					Expect(sess.ExitCode()).To(Equal(0))
+					Expect(atcServer.ReceivedRequests()).To(HaveLen(reqsBefore + 1))
+				})
+			})
+
+			Context("when the pipeline/job doesn't exist", func() {
+				BeforeEach(func() {
+					atcServer.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("POST", path),
+							ghttp.RespondWith(http.StatusNotFound, nil),
+						),
+					)
+				})
+
+				It("prints helpful message", func() {
+					reqsBefore := len(atcServer.ReceivedRequests())
+					flyCmd := exec.Command(flyPath, "-t", targetName, "trigger-job", "-j", "awesome-pipeline/awesome-job")
+
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(sess.Err).Should(gbytes.Say(`pipeline/job 'awesome-pipeline/awesome-job' not found`))
+
+					<-sess.Exited
+					Expect(sess.ExitCode()).To(Equal(1))
+					Expect(atcServer.ReceivedRequests()).To(HaveLen(reqsBefore + 1))
+				})
+			})
+		})
+
+		Context("when the pipeline/job name is not specified", func() {
+			It("errors", func() {
+				reqsBefore := len(atcServer.ReceivedRequests())
+				flyCmd := exec.Command(flyPath, "-t", targetName, "trigger-job")
+
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				<-sess.Exited
+				Expect(sess.ExitCode()).To(Equal(1))
+				Expect(atcServer.ReceivedRequests()).To(HaveLen(reqsBefore))
+			})
+		})
+	})
+})


### PR DESCRIPTION
A/C: As a user I should be able to trigger a job via the fly cli

````
fly -t TARGET trigger-job -j PIPELINE/JOB
```

Signed-off-by: Amin Jamali <ajamali@pivotal.io>