### PR TITLE
Default to hijack'ing into sh if there is no bash

### DIFF
--- a/commands/hijack.go
+++ b/commands/hijack.go
@@ -159,7 +159,7 @@ func remoteCommand(argv []string) (string, []string) {
 
 	switch len(argv) {
 	case 0:
-		path = "bash"
+		path = "bash || sh"
 	case 1:
 		path = argv[0]
 	default:


### PR DESCRIPTION
For example, if your container is off busybox, you don't have bash.

Can't see a good way to test this behavior in the hijack_test.go because atc isn't exposing this sort of behavior. Right?