### PR TITLE
Use HTTPS for Read-Only Access

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Fly is built using [Go](http://golang.org/). Building and testing fly is most ea
 1. Check out concourse and update submodules:
 
   ```bash
-  git clone --recursive git@github.com:concourse/concourse.git
+  git clone --recursive https://github.com:concourse/concourse.git
   cd concourse
   ```
 


### PR DESCRIPTION
The current ssh based URI requires that the user has ssh access.

```
$ git clone --recursive git@github.com:concourse/concourse.git
Cloning into 'concourse'...
Permission denied (publickey).
fatal: Could not read from remote repository.
```

By using `https://` instead it will use read-only by default and allow the user to clone the repo and sub-modules.