### PR TITLE
Update `fly sync` to only download on version mismatch

### DIFF
--- a/commands/sync.go
+++ b/commands/sync.go
@@ -7,6 +7,7 @@ import (
 
 	pb "gopkg.in/cheggaaa/pb.v1"
 
+	"github.com/concourse/fly/version"
 	update "github.com/inconshreveable/go-update"
 
 	"github.com/concourse/fly/commands/internal/displayhelpers"
@@ -19,6 +20,15 @@ func (command *SyncCommand) Execute(args []string) error {
 	target, err := rc.LoadTarget(Fly.Target)
 	if err != nil {
 		return err
+	}
+	info, err := target.Client().GetInfo()
+	if err != nil {
+		return err
+	}
+
+	if info.Version == version.Version {
+		fmt.Printf("Good news! You already have the appropriate fly binary for this target.\n")
+		return nil
 	}
 
 	client := target.Client()

--- a/commands/sync.go
+++ b/commands/sync.go
@@ -27,7 +27,7 @@ func (command *SyncCommand) Execute(args []string) error {
 	}
 
 	if info.Version == version.Version {
-		fmt.Printf("Good news! You already have the appropriate fly binary for this target.\n")
+		fmt.Printf("version already matches; skipping\n")
 		return nil
 	}
 

--- a/integration/sync_test.go
+++ b/integration/sync_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Syncing", func() {
 
 			<-sess.Exited
 			Expect(sess.ExitCode()).To(Equal(0))
-			Expect(sess.Out).To(gbytes.Say(`Good news! You already have the appropriate fly binary for this target.`))
+			Expect(sess.Out).To(gbytes.Say(`version already matches; skipping`))
 
 			contents, err := ioutil.ReadFile(flyPath)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
When `fly sync` is called, it will only download the
new executable, if the `fly` binary is not the same
version as  the ATC version.

Fixes #87