### PR TITLE
Updates Readme to reflect fly sync behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,8 @@ Fly is available for download in the lower right-hand corner of the concourse UI
 
 1. Confirm availability with `which fly`
 
-**Note:** You must use the version of fly that corresponds to your Concourse install. Fly is able to upgrade to the appropriate version for your target by running `fly -t example sync`.
+## Upgrading Fly
+Fly is not available for upgrade independently of Concourse. You can download the corresponding upgraded version of Fly via the following: 
+* using the [Concourse UI](#installing-from-the-concourse-ui-for-project-development) 
+* running `fly -t example sync` if you already have fly locally
+

--- a/README.md
+++ b/README.md
@@ -47,3 +47,5 @@ Fly is available for download in the lower right-hand corner of the concourse UI
   ```
 
 1. Confirm availability with `which fly`
+
+**Note:** You must use the version of fly that corresponds to your Concourse install. Fly is able to upgrade to the appropriate version for your target by running `fly -t example sync`.


### PR DESCRIPTION
I was surprised when I tried to update my version of fly. I did not realize that Concourse specifies the version of fly it needs.