### PR TITLE
[WIP] Add fly-curl command.

### DIFF
--- a/commands/curl.go
+++ b/commands/curl.go
@@ -1,0 +1,78 @@
+package commands
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/textproto"
+	"strings"
+
+	"github.com/concourse/fly/rc"
+)
+
+type CurlCommand struct {
+	PositionalArgs struct {
+		URL string `positional-arg-name:"url" required:"true" description:"Relative URL"`
+	} `positional-args:"yes"`
+	Method  string   `short:"X" long:"X" default:"GET" description:"HTTP method"`
+	Headers []string `short:"H" long:"H" description:"HTTP headers"`
+	Data    string   `short:"d" long:"d" description:"HTTP data"`
+}
+
+func (command *CurlCommand) Execute(args []string) error {
+	url := command.PositionalArgs.URL
+	method := command.Method
+	headers := command.Headers
+	data := command.Data
+
+	target, err := rc.LoadTarget(Fly.Target)
+	if err != nil {
+		return err
+	}
+
+	client := target.HTTPClient()
+
+	req, err := http.NewRequest(method, target.URL()+url, strings.NewReader(data))
+	if err != nil {
+		return err
+	}
+
+	if err := mergeHeaders(req.Header, headers); err != nil {
+		return fmt.Errorf("Error parsing headers: %s", err.Error())
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(body))
+
+	return nil
+}
+
+func mergeHeaders(destination http.Header, headerLines []string) error {
+	headerString := strings.Join(headerLines, "\n")
+	headerString = strings.TrimSpace(headerString)
+	headerString += "\n\n"
+	headerReader := bufio.NewReader(strings.NewReader(headerString))
+	headers, err := textproto.NewReader(headerReader).ReadMIMEHeader()
+	if err != nil {
+		return err
+	}
+
+	for key, values := range headers {
+		destination.Del(key)
+		for _, value := range values {
+			destination.Add(key, value)
+		}
+	}
+
+	return nil
+}

--- a/commands/fly.go
+++ b/commands/fly.go
@@ -52,6 +52,8 @@ type FlyCommand struct {
 
 	Workers     WorkersCommand     `command:"workers" alias:"ws" description:"List the registered workers"`
 	PruneWorker PruneWorkerCommand `command:"prune-worker" alias:"pw" description:"Prune a stalled, landing, landed, or retiring worker"`
+
+	Curl CurlCommand `command:"curl" description:"Send a request to targeted Concourse"`
 }
 
 var Fly FlyCommand

--- a/rc/target.go
+++ b/rc/target.go
@@ -36,6 +36,7 @@ func (e ErrVersionMismatch) Error() string {
 
 type Target interface {
 	Client() concourse.Client
+	HTTPClient() *http.Client
 	Team() concourse.Team
 	CACert() string
 	Validate() error
@@ -233,6 +234,10 @@ func NewNoAuthTarget(
 
 func (t *target) Client() concourse.Client {
 	return t.client
+}
+
+func (t *target) HTTPClient() *http.Client {
+	return t.client.HTTPClient()
 }
 
 func (t *target) Team() concourse.Team {


### PR DESCRIPTION
I use `cf curl` a bunch and would find a similar command for `fly` useful. For example, until there's time to implement #129, this would give users a quick way to list teams from the cli. If this sounds useful, I'll fill in integration tests.