### PR TITLE
Remove 'cute' error message

### DIFF
--- a/integration/error_handling_test.go
+++ b/integration/error_handling_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Fly CLI", func() {
 			Expect(sess.ExitCode()).To(Equal(1))
 
 			Expect(sess.Err).To(gbytes.Say("could not reach the Concourse server called " + targetName))
-			Expect(sess.Err).To(gbytes.Say("lol"))
+			Expect(sess.Err).To(gbytes.Say("running"))
 		})
 	})
 })

--- a/main.go
+++ b/main.go
@@ -37,7 +37,7 @@ func main() {
 			fmt.Fprintln(ui.Stderr, "")
 			fmt.Fprintln(ui.Stderr, "    "+ui.Embolden("%s", netErr))
 			fmt.Fprintln(ui.Stderr, "")
-			fmt.Fprintln(ui.Stderr, "is the targeted Concourse running? better go catch it lol")
+			fmt.Fprintln(ui.Stderr, "is the targeted Concourse running?")
 		} else if err == commands.ErrShowHelpMessage {
 			helpParser := flags.NewParser(&commands.Fly, flags.HelpFlag)
 			helpParser.NamespaceDelimiter = "-"


### PR DESCRIPTION
Reading `fly`'s error feedback `better go catch it lol` the first time was slightly amusing. Reading the cli say `lol` for the twentieth when it fails time becomes quite... annoying.