### PR TITLE
Include 'team' as part of the targets command output

### DIFF
--- a/commands/targets.go
+++ b/commands/targets.go
@@ -24,6 +24,7 @@ func (command *TargetsCommand) Execute([]string) error {
 		Headers: ui.TableRow{
 			{Contents: "name", Color: color.New(color.Bold)},
 			{Contents: "url", Color: color.New(color.Bold)},
+			{Contents: "team", Color: color.New(color.Bold)},
 			{Contents: "expiry", Color: color.New(color.Bold)},
 		},
 	}
@@ -34,6 +35,7 @@ func (command *TargetsCommand) Execute([]string) error {
 		row := ui.TableRow{
 			{Contents: string(targetName)},
 			{Contents: targetValues.API},
+			{Contents: targetValues.TeamName},
 			{Contents: expirationTime},
 		}
 

--- a/integration/fixtures/flyrc.yml
+++ b/integration/fixtures/flyrc.yml
@@ -1,11 +1,13 @@
 targets:
   test:
     api: https://example.com/test
+    team: test
     token:
       type: Bearer
       value: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOiIxNDU4OTQ4NTk3IiwiaXNBZG1pbiI6Im5vcGUiLCJ0ZWFtSUQiOjEsInRlYW1OYW1lIjoibWFpbiJ9.278HuhPsg5mU51ipDI2aVrhzIHfM-a8OcyQ5Us_0faw
   another-test:
     api: https://example.com/another-test
+    team: test
     token:
       type: Bearer
       value: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOiIxNDU4MzUyNDcwIiwiaXNBZG1pbiI6Im5vcGUiLCJ0ZWFtSUQiOjEsInRlYW1OYW1lIjoibWFpbiJ9.v04hbwIFdMNjp6BCpz2jvOYNpAeBY8pio6hlXQizLAM

--- a/integration/logout_test.go
+++ b/integration/logout_test.go
@@ -87,13 +87,14 @@ var _ = Describe("logout Command", func() {
 				Headers: ui.TableRow{
 					{Contents: "name", Color: color.New(color.Bold)},
 					{Contents: "url", Color: color.New(color.Bold)},
+					{Contents: "team", Color: color.New(color.Bold)},
 					{Contents: "expiry", Color: color.New(color.Bold)},
 				},
 				Data: []ui.TableRow{
-					{{Contents: "another-test"}, {Contents: "https://example.com/another-test"}, {Contents: "Sat, 19 Mar 2016 01:54:30 UTC"}},
-					{{Contents: "no-token"}, {Contents: "https://example.com/no-token"}, {Contents: "n/a"}},
-					{{Contents: "omt"}, {Contents: "https://example.com/omt"}, {Contents: "Mon, 21 Mar 2016 01:54:30 UTC"}},
-					{{Contents: "test"}, {Contents: "https://example.com/test"}, {Contents: "Fri, 25 Mar 2016 23:29:57 UTC"}},
+					{{Contents: "another-test"}, {Contents: "https://example.com/another-test"}, {Contents: "test"}, {Contents: "Sat, 19 Mar 2016 01:54:30 UTC"}},
+					{{Contents: "no-token"}, {Contents: "https://example.com/no-token"}, {Contents: "main"}, {Contents: "n/a"}},
+					{{Contents: "omt"}, {Contents: "https://example.com/omt"}, {Contents: "main"}, {Contents: "Mon, 21 Mar 2016 01:54:30 UTC"}},
+					{{Contents: "test"}, {Contents: "https://example.com/test"}, {Contents: "test"}, {Contents: "Fri, 25 Mar 2016 23:29:57 UTC"}},
 				},
 			}))
 		})
@@ -173,10 +174,10 @@ var _ = Describe("logout Command", func() {
 					{Contents: "expiry", Color: color.New(color.Bold)},
 				},
 				Data: []ui.TableRow{
-					{{Contents: "another-test"}, {Contents: "https://example.com/another-test"}, {Contents: "Sat, 19 Mar 2016 01:54:30 UTC"}},
-					{{Contents: "no-token"}, {Contents: "https://example.com/no-token"}, {Contents: "n/a"}},
-					{{Contents: "omt"}, {Contents: "https://example.com/omt"}, {Contents: "Mon, 21 Mar 2016 01:54:30 UTC"}},
-					{{Contents: "test"}, {Contents: "https://example.com/test"}, {Contents: "Fri, 25 Mar 2016 23:29:57 UTC"}},
+					{{Contents: "another-test"}, {Contents: "https://example.com/another-test"}, {Contents: "test"}, {Contents: "Sat, 19 Mar 2016 01:54:30 UTC"}},
+					{{Contents: "no-token"}, {Contents: "https://example.com/no-token"}, {Contents: "main"}, {Contents: "n/a"}},
+					{{Contents: "omt"}, {Contents: "https://example.com/omt"}, {Contents: "main"}, {Contents: "Mon, 21 Mar 2016 01:54:30 UTC"}},
+					{{Contents: "test"}, {Contents: "https://example.com/test"}, {Contents: "test"}, {Contents: "Fri, 25 Mar 2016 23:29:57 UTC"}},
 				},
 			}))
 		})
@@ -191,12 +192,13 @@ var _ = Describe("logout Command", func() {
 				Headers: ui.TableRow{
 					{Contents: "name", Color: color.New(color.Bold)},
 					{Contents: "url", Color: color.New(color.Bold)},
+					{Contents: "team", Color: color.New(color.Bold)},
 					{Contents: "expiry", Color: color.New(color.Bold)},
 				},
 				Data: []ui.TableRow{
-					{{Contents: "another-test"}, {Contents: "https://example.com/another-test"}, {Contents: "Sat, 19 Mar 2016 01:54:30 UTC"}},
-					{{Contents: "no-token"}, {Contents: "https://example.com/no-token"}, {Contents: "n/a"}},
-					{{Contents: "test"}, {Contents: "https://example.com/test"}, {Contents: "Fri, 25 Mar 2016 23:29:57 UTC"}},
+					{{Contents: "another-test"}, {Contents: "https://example.com/another-test"}, {Contents: "test"}, {Contents: "Sat, 19 Mar 2016 01:54:30 UTC"}},
+					{{Contents: "no-token"}, {Contents: "https://example.com/no-token"}, {Contents: "main"}, {Contents: "n/a"}},
+					{{Contents: "test"}, {Contents: "https://example.com/test"}, {Contents: "test"}, {Contents: "Fri, 25 Mar 2016 23:29:57 UTC"}},
 				},
 			}))
 

--- a/integration/targets_test.go
+++ b/integration/targets_test.go
@@ -57,13 +57,14 @@ var _ = Describe("Fly CLI", func() {
 					Headers: ui.TableRow{
 						{Contents: "name", Color: color.New(color.Bold)},
 						{Contents: "url", Color: color.New(color.Bold)},
+						{Contents: "team", Color: color.New(color.Bold)},
 						{Contents: "expiry", Color: color.New(color.Bold)},
 					},
 					Data: []ui.TableRow{
-						{{Contents: "another-test"}, {Contents: "https://example.com/another-test"}, {Contents: "Sat, 19 Mar 2016 01:54:30 UTC"}},
-						{{Contents: "no-token"}, {Contents: "https://example.com/no-token"}, {Contents: "n/a"}},
-						{{Contents: "omt"}, {Contents: "https://example.com/omt"}, {Contents: "Mon, 21 Mar 2016 01:54:30 UTC"}},
-						{{Contents: "test"}, {Contents: "https://example.com/test"}, {Contents: "Fri, 25 Mar 2016 23:29:57 UTC"}},
+						{{Contents: "another-test"}, {Contents: "https://example.com/another-test"}, {Contents: "test"}, {Contents: "Sat, 19 Mar 2016 01:54:30 UTC"}},
+						{{Contents: "no-token"}, {Contents: "https://example.com/no-token"}, {Contents: "main"}, {Contents: "n/a"}},
+						{{Contents: "omt"}, {Contents: "https://example.com/omt"}, {Contents: "main"}, {Contents: "Mon, 21 Mar 2016 01:54:30 UTC"}},
+						{{Contents: "test"}, {Contents: "https://example.com/test"}, {Contents: "test"}, {Contents: "Fri, 25 Mar 2016 23:29:57 UTC"}},
 					},
 				}))
 			})
@@ -83,6 +84,7 @@ var _ = Describe("Fly CLI", func() {
 					Headers: ui.TableRow{
 						{Contents: "name", Color: color.New(color.Bold)},
 						{Contents: "url", Color: color.New(color.Bold)},
+						{Contents: "team", Color: color.New(color.Bold)},
 						{Contents: "expiry", Color: color.New(color.Bold)},
 					},
 					Data: []ui.TableRow{}}))


### PR DESCRIPTION
Per the conversation we had on Slack, this adds `team` listing to `fly targets`.

Before:
```
$ fly targets
name          url                               expiry
another-test  https://example.com/another-test  Sat, 19 Mar 2016 01:54:30 UTC
no-token      https://example.com/no-token      n/a
omt           https://example.com/omt           Mon, 21 Mar 2016 01:54:30 UTC
test          https://example.com/test          Fri, 25 Mar 2016 23:29:57 UTC
```

After: 
```
$ fly targets
name          url                               team  expiry
another-test  https://example.com/another-test  test  Sat, 19 Mar 2016 01:54:30 UTC
no-token      https://example.com/no-token      main  n/a
omt           https://example.com/omt           main  Mon, 21 Mar 2016 01:54:30 UTC
test          https://example.com/test          test  Fri, 25 Mar 2016 23:29:57 UTC
```