### PR TITLE
Add tab completion for fly pipelines.

### DIFF
--- a/commands/checklist.go
+++ b/commands/checklist.go
@@ -5,11 +5,12 @@ import (
 	"sort"
 
 	"github.com/concourse/atc"
+	"github.com/concourse/fly/commands/internal/flaghelpers"
 	"github.com/concourse/fly/rc"
 )
 
 type ChecklistCommand struct {
-	Pipeline string `short:"p" long:"pipeline" required:"true" description:"The pipeline from which to generate the Checkfile"`
+	Pipeline flaghelpers.PipelineFlag `short:"p" long:"pipeline" required:"true" description:"The pipeline from which to generate the Checkfile"`
 }
 
 func (command *ChecklistCommand) Execute([]string) error {
@@ -23,7 +24,7 @@ func (command *ChecklistCommand) Execute([]string) error {
 		return err
 	}
 
-	pipelineName := command.Pipeline
+	pipelineName := string(command.Pipeline)
 
 	config, _, _, _, err := target.Team().PipelineConfig(pipelineName)
 	if err != nil {

--- a/commands/destroy_pipeline.go
+++ b/commands/destroy_pipeline.go
@@ -5,11 +5,13 @@ import (
 
 	"github.com/concourse/fly/rc"
 	"github.com/vito/go-interact/interact"
+
+	"github.com/concourse/fly/commands/internal/flaghelpers"
 )
 
 type DestroyPipelineCommand struct {
-	Pipeline        string `short:"p"  long:"pipeline" required:"true" description:"Pipeline to destroy"`
-	SkipInteractive bool   `short:"n"  long:"non-interactive"          description:"Destroy the pipeline without confirmation"`
+	Pipeline        flaghelpers.PipelineFlag `short:"p"  long:"pipeline" required:"true" description:"Pipeline to destroy"`
+	SkipInteractive bool                     `short:"n"  long:"non-interactive"          description:"Destroy the pipeline without confirmation"`
 }
 
 func (command *DestroyPipelineCommand) Execute(args []string) error {
@@ -23,7 +25,7 @@ func (command *DestroyPipelineCommand) Execute(args []string) error {
 		return err
 	}
 
-	pipelineName := command.Pipeline
+	pipelineName := string(command.Pipeline)
 	fmt.Printf("!!! this will remove all data for pipeline `%s`\n\n", pipelineName)
 
 	confirm := command.SkipInteractive

--- a/commands/expose_pipeline.go
+++ b/commands/expose_pipeline.go
@@ -4,15 +4,16 @@ import (
 	"fmt"
 
 	"github.com/concourse/fly/commands/internal/displayhelpers"
+	"github.com/concourse/fly/commands/internal/flaghelpers"
 	"github.com/concourse/fly/rc"
 )
 
 type ExposePipelineCommand struct {
-	Pipeline string `short:"p" long:"pipeline" required:"true" description:"Pipeline to expose"`
+	Pipeline flaghelpers.PipelineFlag `short:"p" long:"pipeline" required:"true" description:"Pipeline to expose"`
 }
 
 func (command *ExposePipelineCommand) Execute(args []string) error {
-	pipelineName := command.Pipeline
+	pipelineName := string(command.Pipeline)
 
 	target, err := rc.LoadTarget(Fly.Target)
 	if err != nil {

--- a/commands/get_pipeline.go
+++ b/commands/get_pipeline.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/concourse/atc"
 	"github.com/concourse/fly/commands/internal/displayhelpers"
+	"github.com/concourse/fly/commands/internal/flaghelpers"
 	"github.com/concourse/fly/rc"
 	"github.com/concourse/fly/ui"
 	"github.com/concourse/go-concourse/concourse"
@@ -16,13 +17,13 @@ import (
 )
 
 type GetPipelineCommand struct {
-	Pipeline string `short:"p" long:"pipeline" required:"true" description:"Get configuration of this pipeline"`
-	JSON     bool   `short:"j" long:"json"                     description:"Print config as json instead of yaml"`
+	Pipeline flaghelpers.PipelineFlag `short:"p" long:"pipeline" required:"true" description:"Get configuration of this pipeline"`
+	JSON     bool                     `short:"j" long:"json"                     description:"Print config as json instead of yaml"`
 }
 
 func (command *GetPipelineCommand) Execute(args []string) error {
 	asJSON := command.JSON
-	pipelineName := command.Pipeline
+	pipelineName := string(command.Pipeline)
 
 	target, err := rc.LoadTarget(Fly.Target)
 	if err != nil {

--- a/commands/hide_pipeline.go
+++ b/commands/hide_pipeline.go
@@ -4,15 +4,16 @@ import (
 	"fmt"
 
 	"github.com/concourse/fly/commands/internal/displayhelpers"
+	"github.com/concourse/fly/commands/internal/flaghelpers"
 	"github.com/concourse/fly/rc"
 )
 
 type HidePipelineCommand struct {
-	Pipeline string `short:"p" long:"pipeline" required:"true" description:"Pipeline to ide"`
+	Pipeline flaghelpers.PipelineFlag `short:"p" long:"pipeline" required:"true" description:"Pipeline to ide"`
 }
 
 func (command *HidePipelineCommand) Execute(args []string) error {
-	pipelineName := command.Pipeline
+	pipelineName := string(command.Pipeline)
 
 	target, err := rc.LoadTarget(Fly.Target)
 	if err != nil {

--- a/commands/internal/flaghelpers/pipeline_flag.go
+++ b/commands/internal/flaghelpers/pipeline_flag.go
@@ -1,0 +1,57 @@
+package flaghelpers
+
+import (
+	"os"
+	"strings"
+
+	"github.com/jessevdk/go-flags"
+
+	"github.com/concourse/fly/rc"
+)
+
+type flyCommand struct {
+	Target rc.TargetName `short:"t" long:"target" description:"Concourse target name"`
+}
+
+var fly flyCommand
+
+type PipelineFlag string
+
+func (flag *PipelineFlag) Complete(match string) []flags.Completion {
+	// Prevent go-flags from recursing
+	goFlagsCompletion, hasCompletion := os.LookupEnv("GO_FLAGS_COMPLETION")
+	os.Unsetenv("GO_FLAGS_COMPLETION")
+	defer func() {
+		if hasCompletion {
+			os.Setenv("GO_FLAGS_COMPLETION", goFlagsCompletion)
+		}
+	}()
+
+	parser := flags.NewParser(&fly, flags.HelpFlag|flags.PassDoubleDash)
+	parser.NamespaceDelimiter = "-"
+	parser.Parse()
+
+	target, err := rc.LoadTarget(fly.Target)
+	if err != nil {
+		return []flags.Completion{}
+	}
+
+	err = target.Validate()
+	if err != nil {
+		return []flags.Completion{}
+	}
+
+	pipelines, err := target.Team().ListPipelines()
+	if err != nil {
+		return []flags.Completion{}
+	}
+
+	comps := []flags.Completion{}
+	for _, pipeline := range pipelines {
+		if strings.HasPrefix(pipeline.Name, match) {
+			comps = append(comps, flags.Completion{Item: pipeline.Name})
+		}
+	}
+
+	return comps
+}

--- a/commands/pause_pipeline.go
+++ b/commands/pause_pipeline.go
@@ -4,15 +4,16 @@ import (
 	"fmt"
 
 	"github.com/concourse/fly/commands/internal/displayhelpers"
+	"github.com/concourse/fly/commands/internal/flaghelpers"
 	"github.com/concourse/fly/rc"
 )
 
 type PausePipelineCommand struct {
-	Pipeline string `short:"p"  long:"pipeline" required:"true" description:"Pipeline to pause"`
+	Pipeline flaghelpers.PipelineFlag `short:"p"  long:"pipeline" required:"true" description:"Pipeline to pause"`
 }
 
 func (command *PausePipelineCommand) Execute(args []string) error {
-	pipelineName := command.Pipeline
+	pipelineName := string(command.Pipeline)
 
 	target, err := rc.LoadTarget(Fly.Target)
 	if err != nil {

--- a/commands/rename_pipeline.go
+++ b/commands/rename_pipeline.go
@@ -4,15 +4,16 @@ import (
 	"fmt"
 
 	"github.com/concourse/fly/commands/internal/displayhelpers"
+	"github.com/concourse/fly/commands/internal/flaghelpers"
 	"github.com/concourse/fly/rc"
 )
 
 type RenamePipelineCommand struct {
-	Pipeline string `short:"o"  long:"old-name" required:"true"  description:"Pipeline to rename"`
-	Name     string `short:"n"  long:"new-name" required:"true"  description:"Name to set as pipeline name"`
+	Pipeline flaghelpers.PipelineFlag `short:"o"  long:"old-name" required:"true"  description:"Pipeline to rename"`
+	Name     string                   `short:"n"  long:"new-name" required:"true"  description:"Name to set as pipeline name"`
 }
 
-func (rp *RenamePipelineCommand) Execute([]string) error {
+func (command *RenamePipelineCommand) Execute([]string) error {
 	target, err := rc.LoadTarget(Fly.Target)
 	if err != nil {
 		return err
@@ -23,17 +24,19 @@ func (rp *RenamePipelineCommand) Execute([]string) error {
 		return err
 	}
 
-	found, err := target.Team().RenamePipeline(rp.Pipeline, rp.Name)
+	pipelineName := string(command.Pipeline)
+
+	found, err := target.Team().RenamePipeline(pipelineName, command.Name)
 	if err != nil {
 		return err
 	}
 
 	if !found {
-		displayhelpers.Failf("pipeline '%s' not found\n", rp.Pipeline)
+		displayhelpers.Failf("pipeline '%s' not found\n", pipelineName)
 		return nil
 	}
 
-	fmt.Printf("pipeline successfully renamed to %s\n", rp.Name)
+	fmt.Printf("pipeline successfully renamed to %s\n", command.Name)
 
 	return nil
 }

--- a/commands/set_pipeline.go
+++ b/commands/set_pipeline.go
@@ -11,7 +11,7 @@ import (
 )
 
 type SetPipelineCommand struct {
-	Pipeline        string                         `short:"p"  long:"pipeline" required:"true"      description:"Pipeline to configure"`
+	Pipeline        flaghelpers.PipelineFlag       `short:"p"  long:"pipeline" required:"true"      description:"Pipeline to configure"`
 	Config          atc.PathFlag                   `short:"c"  long:"config" required:"true"        description:"Pipeline configuration file"`
 	Var             []flaghelpers.VariablePairFlag `short:"v"  long:"var" value-name:"[SECRET=KEY]" description:"Variable flag that can be used for filling in template values in configuration"`
 	VarsFrom        []atc.PathFlag                 `short:"l"  long:"load-vars-from"                description:"Variable flag that can be used for filling in template values in configuration from a YAML file"`
@@ -21,7 +21,7 @@ type SetPipelineCommand struct {
 func (command *SetPipelineCommand) Execute(args []string) error {
 	configPath := command.Config
 	templateVariablesFiles := command.VarsFrom
-	pipelineName := command.Pipeline
+	pipelineName := string(command.Pipeline)
 
 	templateVariables := template.Variables{}
 	for _, v := range command.Var {

--- a/commands/unpause_pipeline.go
+++ b/commands/unpause_pipeline.go
@@ -4,15 +4,16 @@ import (
 	"fmt"
 
 	"github.com/concourse/fly/commands/internal/displayhelpers"
+	"github.com/concourse/fly/commands/internal/flaghelpers"
 	"github.com/concourse/fly/rc"
 )
 
 type UnpausePipelineCommand struct {
-	Pipeline string `short:"p" long:"pipeline" required:"true" description:"Pipeline to unpause"`
+	Pipeline flaghelpers.PipelineFlag `short:"p" long:"pipeline" required:"true" description:"Pipeline to unpause"`
 }
 
 func (command *UnpausePipelineCommand) Execute(args []string) error {
-	pipelineName := command.Pipeline
+	pipelineName := string(command.Pipeline)
 
 	target, err := rc.LoadTarget(Fly.Target)
 	if err != nil {

--- a/integration/pipelines_test.go
+++ b/integration/pipelines_test.go
@@ -99,7 +99,6 @@ var _ = Describe("Fly CLI", func() {
 
 			Context("completion", func() {
 				BeforeEach(func() {
-					os.Setenv("GO_FLAGS_COMPLETION", "1")
 					atcServer.AppendHandlers(
 						ghttp.CombineHandlers(
 							ghttp.VerifyRequest("GET", "/api/v1/teams/main/pipelines"),
@@ -112,12 +111,9 @@ var _ = Describe("Fly CLI", func() {
 					)
 				})
 
-				AfterEach(func() {
-					os.Unsetenv("GO_FLAGS_COMPLETION")
-				})
-
 				It("returns all matching pipelines", func() {
 					flyCmd := exec.Command(flyPath, "-t", targetName, "get-pipeline", "-p", "some-")
+					flyCmd.Env = append(os.Environ(), "GO_FLAGS_COMPLETION=1")
 					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 					Expect(err).NotTo(HaveOccurred())
 					Eventually(sess).Should(gexec.Exit(0))


### PR DESCRIPTION
This is kind of a kludge. To get completion for the `--pipeline` flag, we need to know the value of `--target` if any, so we pretend we're not in a completion check and re-parse the args to see if the target is set. If this makes sense, I'll fill in tests.