### PR TITLE
Added ssl client auth support

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,4 +1,4 @@
-Copyright 2014-2016 Alex Suraci, Chris Brown, and Pivotal Software, Inc.
+Copyright 2014-2017 Alex Suraci, Chris Brown, Google Inc, and Pivotal Software, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License. You may obtain a copy of the

--- a/integration/execute_test.go
+++ b/integration/execute_test.go
@@ -566,6 +566,8 @@ run:
 				"some-team",
 				&token,
 				"",
+				"",
+				"",
 			)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/rc/target_test.go
+++ b/rc/target_test.go
@@ -76,6 +76,7 @@ AA9WjQKZ7aKQRUzkuxCkPfAyAw7xzvjoyVGM5mKf5p/AfbdynMk2OmufTqj/ZA1k
 				base, ok := (*transport).Base.(*http.Transport)
 				Expect(ok).To(BeTrue())
 				Expect((*base).TLSClientConfig).To(Equal(&tls.Config{
+					Certificates:       []tls.Certificate{},
 					InsecureSkipVerify: true,
 					RootCAs:            nil,
 				}))
@@ -126,6 +127,7 @@ AA9WjQKZ7aKQRUzkuxCkPfAyAw7xzvjoyVGM5mKf5p/AfbdynMk2OmufTqj/ZA1k
 				Expect(ok).To(BeTrue())
 
 				Expect((*base).TLSClientConfig).To(Equal(&tls.Config{
+					Certificates:       []tls.Certificate{},
 					InsecureSkipVerify: false,
 					RootCAs:            expectedCaCertPool,
 				}))

--- a/rc/targets.go
+++ b/rc/targets.go
@@ -24,16 +24,22 @@ func (err UnknownTargetError) Error() string {
 }
 
 type TargetProps struct {
-	API      string       `yaml:"api"`
-	TeamName string       `yaml:"team"`
-	Insecure bool         `yaml:"insecure,omitempty"`
-	Token    *TargetToken `yaml:"token,omitempty"`
-	CACert   string       `yaml:"ca_cert,omitempty"`
+	API        string       `yaml:"api"`
+	TeamName   string       `yaml:"team"`
+	Insecure   bool         `yaml:"insecure,omitempty"`
+	Token      *TargetToken `yaml:"token,omitempty"`
+	CACert     string       `yaml:"ca_cert,omitempty"`
+	ClientCert *ClientCert  `yaml:"client_cert,omitempty"`
 }
 
 type TargetToken struct {
 	Type  string `yaml:"type"`
 	Value string `yaml:"value"`
+}
+
+type ClientCert struct {
+	Cert string `yaml:"cert"`
+	Key  string `yaml:"key"`
 }
 
 type targetDetailsYAML struct {
@@ -64,6 +70,8 @@ func SaveTarget(
 	teamName string,
 	token *TargetToken,
 	caCert string,
+	clientCert string,
+	clientCertKey string,
 ) error {
 	flyTargets, err := LoadTargets()
 	if err != nil {
@@ -77,6 +85,7 @@ func SaveTarget(
 	newInfo.Token = token
 	newInfo.TeamName = teamName
 	newInfo.CACert = caCert
+	newInfo.ClientCert = &ClientCert{Cert: clientCert, Key: clientCertKey}
 
 	flyTargets.Targets[targetName] = newInfo
 	return writeTargets(flyrc, flyTargets)

--- a/rc/targets_test.go
+++ b/rc/targets_test.go
@@ -71,6 +71,8 @@ var _ = Describe("Targets", func() {
 						"main",
 						nil,
 						"",
+						"",
+						"",
 					)
 					Expect(err).ToNot(HaveOccurred())
 				})
@@ -94,6 +96,8 @@ var _ = Describe("Targets", func() {
 						"main",
 						nil,
 						rsaCertPEM,
+						"",
+						"",
 					)
 					Expect(err).ToNot(HaveOccurred())
 				})
@@ -119,6 +123,8 @@ var _ = Describe("Targets", func() {
 						"main",
 						nil,
 						"",
+						"",
+						"",
 					)
 					Expect(err).ToNot(HaveOccurred())
 				})
@@ -141,6 +147,8 @@ var _ = Describe("Targets", func() {
 						true,
 						"main",
 						nil,
+						"",
+						"",
 						"",
 					)
 					Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
This is a simple extension that allows fly to authorize against concourse ci servers that require client certificate validation.

Note that this doesn't change any auth mechanisms of concourse itself, it only adds client ssl as an optional layer to any other auth option.

Given that the server doesn't do any client auth out of the box, this option is useful where concourse runs behind a reverse proxy that does ssl termination (e.g. nginx that checks client certs).