### PR TITLE
Support specifying target with $FLY_TARGET

### DIFF
--- a/commands/fly.go
+++ b/commands/fly.go
@@ -5,7 +5,7 @@ import "github.com/concourse/fly/rc"
 type FlyCommand struct {
 	Help HelpCommand `command:"help" description:"Print this help message"`
 
-	Target  rc.TargetName  `short:"t" long:"target" description:"Concourse target name"`
+	Target  rc.TargetName  `short:"t" long:"target" env:"FLY_TARGET" description:"Concourse target name"`
 	Targets TargetsCommand `command:"targets" alias:"ts" description:"List saved targets"`
 
 	Version func() `short:"v" long:"version" description:"Print the version of Fly and exit"`


### PR DESCRIPTION
I'd find it helpful to rely on environment variables rather than specifying `-t something` in my commands. Thoughts?

```
$ fly --help 2>&1 | grep -- --target
  -t, --target=              Concourse target name [$FLY_TARGET]
```