### PR TITLE
Use a semver library to parse versions

### DIFF
--- a/version/version_test.go
+++ b/version/version_test.go
@@ -16,11 +16,41 @@ var _ = Describe("Version", func() {
 		Expect(patch).To(Equal(3))
 	})
 
-	It("can detect development versions", func() {
-		isDev := IsDev("1.2.3")
-		Expect(isDev).To(BeFalse())
+	It("returns an error for non-parsable versions", func() {
+		_, _, _, err := GetSemver("")
+		Expect(err).To(HaveOccurred())
+		_, _, _, err = GetSemver("1.2")
+		Expect(err).To(HaveOccurred())
+	})
 
-		isDev = IsDev("0.0.0-dev")
-		Expect(isDev).To(BeTrue())
+	It("parses pre-release versions", func() {
+		major, minor, patch, err := GetSemver("1.2.3-dev.2")
+		Expect(err).To(Succeed())
+		Expect(major).To(Equal(1))
+		Expect(minor).To(Equal(2))
+		Expect(patch).To(Equal(3))
+	})
+
+	It("parses post-release versions", func() {
+		major, minor, patch, err := GetSemver("1.2.3+bonus_feature.1")
+		Expect(err).To(Succeed())
+		Expect(major).To(Equal(1))
+		Expect(minor).To(Equal(2))
+		Expect(patch).To(Equal(3))
+	})
+
+	It("can detect development versions", func() {
+		Expect(IsDev("1.2.3")).To(BeFalse())
+		Expect(IsDev("0.0.0-dev")).To(BeTrue())
+
+		Expect(IsDev("0.0.0-devolve")).To(BeFalse())
+		Expect(IsDev("0.0.0-not-dev")).To(BeFalse())
+		Expect(IsDev("0.0.0+not+dev")).To(BeFalse())
+
+		Expect(IsDev("0.0.0-dev.1")).To(BeTrue())
+		Expect(IsDev("0.0.0-abc+dev")).To(BeTrue())
+		Expect(IsDev("0.0.0-abc+dev.1")).To(BeTrue())
+		Expect(IsDev("0.0.0-dev+dev")).To(BeTrue())
+		Expect(IsDev("0.0.0-abc+dev.1")).To(BeTrue())
 	})
 })


### PR DESCRIPTION
fly login would die with an error:
error: strconv.ParseInt: parsing "0+foo.1": invalid syntax
This is because it split the version on three dot-separated components,
and assumes they are all numbers.

Replace this inflexible parsing with a library that was built to parse
versions with pre- and post-release version segment.

We still assume the main release segment has 3 integer components, since
this seems in keeping with Concourse's versioning practice.

Signed-off-by: David Sharp <dsharp@pivotal.io>