### PR TITLE
Hijack by url

### DIFF
--- a/commands/hijack.go
+++ b/commands/hijack.go
@@ -48,6 +48,12 @@ func (command *HijackCommand) Execute([]string) error {
 	if err != nil {
 		return err
 	}
+
+	if(fingerprint.team != "" && fingerprint.team != target.Team().Name()) {
+		err = fmt.Errorf("Team in URL doesn't match the current team of the target")
+		return err
+	}
+
 	containers, err := command.getContainerIDs(target.Client(), fingerprint)
 	if err != nil {
 		return err
@@ -185,6 +191,7 @@ func parseUrl(concourseUrl string) (map[string]string, error) {
 }
 
 func (command *HijackCommand) getContainerFingerprint(client concourse.Client) (*containerFingerprint, error) {
+	var team string
 	var pipelineName string
 	if command.Job.PipelineName != "" {
 		pipelineName = command.Job.PipelineName
@@ -209,6 +216,7 @@ func (command *HijackCommand) getContainerFingerprint(client concourse.Client) (
 		jobName = urlMap["jobs"]
 		buildNameOrID = urlMap["builds"]
 		check = urlMap["resources"]
+		team = urlMap["teams"]
 	}
 
 	fingerprint := containerFingerprint{
@@ -218,6 +226,7 @@ func (command *HijackCommand) getContainerFingerprint(client concourse.Client) (
 		stepName:      stepName,
 		checkName:     check,
 		attempt:       attempt,
+		team:          team,
 	}
 
 	return &fingerprint, nil
@@ -317,6 +326,7 @@ type containerFingerprint struct {
 
 	checkName string
 	attempt   string
+	team      string
 }
 
 func locateContainer(client concourse.Client, fingerprint *containerFingerprint) (map[string]string, error) {

--- a/integration/hijack_test.go
+++ b/integration/hijack_test.go
@@ -434,7 +434,7 @@ var _ = Describe("Hijacking", func() {
 
 			Context("and with url specified", func() {
 				It("hijacks the given check container by URL", func() {
-					hijack("--url", "http://example.com/teams/"+teamName+"/pipelines/a-pipeline/resources/some-resource-name")
+					hijack("--url", atcServer.URL()+"/teams/"+teamName+"/pipelines/a-pipeline/resources/some-resource-name")
 				})
 			})
 		})
@@ -467,7 +467,7 @@ var _ = Describe("Hijacking", func() {
 			})
 
 			It("hijacks the job's next build when URL is specified", func() {
-				hijack("--url", "http://example.com/teams/"+teamName+"/pipelines/some-pipeline/jobs/some-job", "--step", "some-step")
+				hijack("--url", atcServer.URL()+"/teams/"+teamName+"/pipelines/some-pipeline/jobs/some-job", "--step", "some-step")
 			})
 
 			Context("with a specific build of the job", func() {
@@ -480,7 +480,7 @@ var _ = Describe("Hijacking", func() {
 				})
 
 				It("hijacks the given build when URL", func() {
-					hijack("--url", "http://example.com/teams/"+teamName+"/pipelines/some-pipeline/jobs/some-job/builds/3", "--step", "some-step")
+					hijack("--url", atcServer.URL()+"/teams/"+teamName+"/pipelines/some-pipeline/jobs/some-job/builds/3", "--step", "some-step")
 				})
 			})
 		})
@@ -551,12 +551,24 @@ var _ = Describe("Hijacking", func() {
 
 	Context("when passing a URL that doesn't match the target", func() {
 		It("errors out when wrong team is specified", func() {
-			flyCmd := exec.Command(flyPath, "-t", targetName, "hijack", "--url", "http://example.com/teams/wrongteam/pipelines/a-pipeline/resources/some-resource-name")
+			flyCmd := exec.Command(flyPath, "-t", targetName, "hijack", "--url", atcServer.URL()+"/teams/wrongteam/pipelines/a-pipeline/resources/some-resource-name")
 
 			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(sess.Err.Contents).Should(ContainSubstring("Team in URL doesn't match the current team of the target"))
+
+			<-sess.Exited
+			Expect(sess.ExitCode()).ToNot(Equal(0))
+		})
+
+		It("errors out when wrong URL is specified", func() {
+			flyCmd := exec.Command(flyPath, "-t", targetName, "hijack", "--url", "http://wrong.example.com/teams/"+teamName+"/pipelines/a-pipeline/resources/some-resource-name")
+
+			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(sess.Err.Contents).Should(ContainSubstring("URL doesn't match that of target"))
 
 			<-sess.Exited
 			Expect(sess.ExitCode()).ToNot(Equal(0))

--- a/integration/hijack_test.go
+++ b/integration/hijack_test.go
@@ -434,7 +434,7 @@ var _ = Describe("Hijacking", func() {
 
 			Context("and with url specified", func() {
 				It("hijacks the given check container by URL", func() {
-					hijack("--url", "http://example.com/teams/mighty-ducks/pipelines/a-pipeline/resources/some-resource-name")
+					hijack("--url", "http://example.com/teams/"+teamName+"/pipelines/a-pipeline/resources/some-resource-name")
 				})
 			})
 		})
@@ -467,7 +467,7 @@ var _ = Describe("Hijacking", func() {
 			})
 
 			It("hijacks the job's next build when URL is specified", func() {
-				hijack("--url", "http://example.com/teams/mighty-ducks/pipelines/some-pipeline/jobs/some-job", "--step", "some-step")
+				hijack("--url", "http://example.com/teams/"+teamName+"/pipelines/some-pipeline/jobs/some-job", "--step", "some-step")
 			})
 
 			Context("with a specific build of the job", func() {
@@ -479,8 +479,8 @@ var _ = Describe("Hijacking", func() {
 					hijack("--job", "some-pipeline/some-job", "--build", "3", "--step", "some-step")
 				})
 
-				It("hijacks the given build when URL is specified", func() {
-					hijack("--url", "http://example.com/teams/mighty-ducks/pipelines/some-pipeline/jobs/some-job/builds/3", "--step", "some-step")
+				It("hijacks the given build when URL", func() {
+					hijack("--url", "http://example.com/teams/"+teamName+"/pipelines/some-pipeline/jobs/some-job/builds/3", "--step", "some-step")
 				})
 			})
 		})
@@ -546,6 +546,20 @@ var _ = Describe("Hijacking", func() {
 				<-sess.Exited
 				Expect(sess.ExitCode()).To(Equal(255))
 			})
+		})
+	})
+
+	Context("when passing a URL that doesn't match the target", func() {
+		It("errors out when wrong team is specified", func() {
+			flyCmd := exec.Command(flyPath, "-t", targetName, "hijack", "--url", "http://example.com/teams/wrongteam/pipelines/a-pipeline/resources/some-resource-name")
+
+			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(sess.Err.Contents).Should(ContainSubstring("Team in URL doesn't match the current team of the target"))
+
+			<-sess.Exited
+			Expect(sess.ExitCode()).ToNot(Equal(0))
 		})
 	})
 })

--- a/integration/hijack_test.go
+++ b/integration/hijack_test.go
@@ -471,6 +471,10 @@ var _ = Describe("Hijacking", func() {
 				It("hijacks the given build", func() {
 					hijack("--job", "some-pipeline/some-job", "--build", "3", "--step", "some-step")
 				})
+
+				It("hijacks the given build by URL", func() {
+					hijack("--url", "http://example.com/teams/mighty-ducks/pipelines/some-pipeline/jobs/some-job/builds/3", "--step", "some-step")
+				})
 			})
 		})
 

--- a/integration/hijack_test.go
+++ b/integration/hijack_test.go
@@ -423,15 +423,18 @@ var _ = Describe("Hijacking", func() {
 		Context("when called with check container", func() {
 			BeforeEach(func() {
 				resourceName = "some-resource-name"
+				containerArguments = "type=check&resource_name=some-resource-name&pipeline_name=a-pipeline"
 			})
 
 			Context("and with pipeline specified", func() {
-				BeforeEach(func() {
-					containerArguments = "type=check&resource_name=some-resource-name&pipeline_name=a-pipeline"
-				})
-
 				It("can accept the check resources name and a pipeline", func() {
 					hijack("--check", "a-pipeline/some-resource-name")
+				})
+			})
+
+			Context("and with url specified", func() {
+				It("hijacks the given check container by URL", func() {
+					hijack("--url", "http://example.com/teams/mighty-ducks/pipelines/a-pipeline/resources/some-resource-name")
 				})
 			})
 		})
@@ -463,6 +466,10 @@ var _ = Describe("Hijacking", func() {
 				hijack("--job", "some-pipeline/some-job", "--step", "some-step")
 			})
 
+			It("hijacks the job's next build when URL is specified", func() {
+				hijack("--url", "http://example.com/teams/mighty-ducks/pipelines/some-pipeline/jobs/some-job", "--step", "some-step")
+			})
+
 			Context("with a specific build of the job", func() {
 				BeforeEach(func() {
 					containerArguments = "pipeline_name=some-pipeline&job_name=some-job&build_name=3&step_name=some-step"
@@ -472,7 +479,7 @@ var _ = Describe("Hijacking", func() {
 					hijack("--job", "some-pipeline/some-job", "--build", "3", "--step", "some-step")
 				})
 
-				It("hijacks the given build by URL", func() {
+				It("hijacks the given build when URL is specified", func() {
 					hijack("--url", "http://example.com/teams/mighty-ducks/pipelines/some-pipeline/jobs/some-job/builds/3", "--step", "some-step")
 				})
 			})

--- a/integration/suite_test.go
+++ b/integration/suite_test.go
@@ -24,6 +24,7 @@ var homeDir string
 var atcServer *ghttp.Server
 
 const targetName = "testserver"
+const teamName   = "main"
 const atcVersion = "1.2.3"
 
 var _ = SynchronizedBeforeSuite(func() []byte {
@@ -76,10 +77,10 @@ var _ = BeforeEach(func() {
 	atcServer.AppendHandlers(
 		infoHandler(),
 		ghttp.CombineHandlers(
-			ghttp.VerifyRequest("GET", "/api/v1/teams/main/auth/methods"),
+			ghttp.VerifyRequest("GET", "/api/v1/teams/"+teamName+"/auth/methods"),
 			ghttp.RespondWithJSONEncoded(200, []atc.AuthMethod{}),
 		),
-		tokenHandler("main"),
+		tokenHandler(teamName),
 		infoHandler(),
 	)
 
@@ -89,7 +90,7 @@ var _ = BeforeEach(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	os.Setenv("HOME", homeDir)
-	loginCmd := exec.Command(flyPath, "-t", targetName, "login", "-c", atcServer.URL())
+	loginCmd := exec.Command(flyPath, "-t", targetName, "login", "-c", atcServer.URL(), "-n", teamName)
 
 	session, err := gexec.Start(loginCmd, GinkgoWriter, GinkgoWriter)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
This adds a feature to fly hijack to use a Concourse UI URL to help identify the container to connect to. It also checks that the target's URL and team match that in the passed URL.