### PR TITLE
Add fmt command

### DIFF
--- a/commands/fly.go
+++ b/commands/fly.go
@@ -5,6 +5,8 @@ import "github.com/concourse/fly/rc"
 type FlyCommand struct {
 	Help HelpCommand `command:"help" description:"Print this help message"`
 
+	Fmt FmtCommand `command:"fmt" description:"Format a pipeline config"`
+
 	Target  rc.TargetName  `short:"t" long:"target" description:"Concourse target name"`
 	Targets TargetsCommand `command:"targets" alias:"ts" description:"List saved targets"`
 

--- a/commands/fmt.go
+++ b/commands/fmt.go
@@ -1,0 +1,64 @@
+package commands
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/concourse/atc"
+	"github.com/concourse/fly/commands/internal/displayhelpers"
+	yamlpatch "github.com/krishicks/yaml-patch"
+)
+
+type FmtCommand struct {
+	Config atc.PathFlag `short:"c" long:"config" required:"true" description:"Pipeline configuration file"`
+	Write  bool         `short:"w" long:"write" description:"Do not print to stdout; overwrite the file in place"`
+}
+
+func (command *FmtCommand) Execute(args []string) error {
+	configPath := string(command.Config)
+	configBytes, err := ioutil.ReadFile(configPath)
+	if err != nil {
+		displayhelpers.FailWithErrorf("could not read config file", err)
+	}
+
+	placeholderWrapper := yamlpatch.NewPlaceholderWrapper("{{", "}}")
+	wrappedConfigBytes := placeholderWrapper.Wrap(configBytes)
+
+	var config atc.Config
+	err = yaml.Unmarshal(wrappedConfigBytes, &config)
+	if err != nil {
+		displayhelpers.FailWithErrorf("could not unmarshal config", err)
+	}
+
+	formattedBytes, err := yaml.Marshal(config)
+	if err != nil {
+		displayhelpers.FailWithErrorf("could not marshal config", err)
+	}
+
+	if !bytes.Equal(configBytes, formattedBytes) {
+		unwrappedConfigBytes := placeholderWrapper.Unwrap(formattedBytes)
+
+		if command.Write {
+			fi, err := os.Stat(configPath)
+			if err != nil {
+				displayhelpers.FailWithErrorf("could not stat config file", err)
+			}
+
+			err = ioutil.WriteFile(configPath, unwrappedConfigBytes, fi.Mode())
+			if err != nil {
+				displayhelpers.FailWithErrorf("could not write formatted config to %s", err, command.Config)
+			}
+		} else {
+			_, err = fmt.Fprint(os.Stdout, string(unwrappedConfigBytes))
+			if err != nil {
+				displayhelpers.FailWithErrorf("could not write formatted config to stdout", err)
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
This introduces `fly fmt` in the spirit of `go fmt`, which is useful for people that use [yaml-patch](github.com/krishicks/yaml-patch) to modify their Concourse pipelines (yaml-patch isn't aware of Concourse pipelines, only YAML).

It presently uses a little thing I wrote for yaml-patch to handle placeholders in the pipeline:

Because `key: {{placeholder}}` is invalid YAML we have to wrap the placeholder in quotes to make it valid yaml just to unmarshal it into an atc.Config. Later, we need to unwrap the quotes from the placeholder.

If it's a requirement I can pull that out into a separate thing so as to not have to bring in all of yaml-patch just for this.

This PR is more to get the conversation started and a review of the implementation going.