### PR TITLE
abort build using build id

### DIFF
--- a/commands/abort_build.go
+++ b/commands/abort_build.go
@@ -4,13 +4,14 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/concourse/atc"
 	"github.com/concourse/fly/commands/internal/flaghelpers"
 	"github.com/concourse/fly/rc"
 )
 
 type AbortBuildCommand struct {
-	Job   flaghelpers.JobFlag `short:"j" long:"job"   required:"true" value-name:"PIPELINE/JOB"   description:"Name of a job to cancel"`
-	Build string              `short:"b" long:"build" required:"true" description:"Name of the build to cancel"`
+	Job   flaghelpers.JobFlag `short:"j" long:"job" value-name:"PIPELINE/JOB"   description:"Name of a job to cancel"`
+	Build string              `short:"b" long:"build" required:"true" description:"If job is specified: build number to cancel. If job not specified: build id"`
 }
 
 func (command *AbortBuildCommand) Execute([]string) error {
@@ -24,13 +25,19 @@ func (command *AbortBuildCommand) Execute([]string) error {
 		return err
 	}
 
-	build, exists, err := target.Team().JobBuild(command.Job.PipelineName, command.Job.JobName, command.Build)
+	var build atc.Build
+	var exists bool
+	if command.Job.PipelineName == "" && command.Job.JobName == "" {
+		build, exists, err = target.Client().Build(command.Build)
+	} else {
+		build, exists, err = target.Team().JobBuild(command.Job.PipelineName, command.Job.JobName, command.Build)
+	}
 	if err != nil {
 		return err
 	}
 
 	if !exists {
-		return fmt.Errorf("job build does not exist")
+		return fmt.Errorf("build does not exist")
 	}
 
 	if err := target.Client().AbortBuild(strconv.Itoa(build.ID)); err != nil {


### PR DESCRIPTION
This is just a proof of concept. I am reusing the `-b` flag to double as build number of build id depending on whether the `-j` flag is present. Examples:
```bash
# Abort build with build id 23
fly abort-build -b 23
# Abort build number 42 from pipeline my-pipeline, job my-job
fly abort-build -j my-pipeline/my-job -b 42
```