### PR TITLE
Write help message when typing just `fly`

### DIFF
--- a/integration/help_test.go
+++ b/integration/help_test.go
@@ -26,4 +26,21 @@ var _ = Describe("Fly CLI", func() {
 			Expect(sess.Out).To(gbytes.Say("Available commands:"))
 		})
 	})
+
+	Context("when invoking binary without flags", func() {
+		It("prints help", func() {
+			flyCmd := exec.Command(flyPath)
+
+			sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			<-sess.Exited
+			Expect(sess.ExitCode()).To(Equal(0))
+
+			Expect(sess.Out).To(gbytes.Say("Usage:"))
+			Expect(sess.Out).To(gbytes.Say("Application Options:"))
+			Expect(sess.Out).To(gbytes.Say("Help Options:"))
+			Expect(sess.Out).To(gbytes.Say("Available commands:"))
+		})
+	})
 })

--- a/main.go
+++ b/main.go
@@ -40,31 +40,25 @@ func main() {
 
 	commands.Fly.SetTeam.ProviderAuth = authConfigs
 
+	helpParser := flags.NewParser(&commands.Fly, flags.HelpFlag)
+	helpParser.NamespaceDelimiter = "-"
+
 	_, err := parser.Parse()
 	if err != nil {
 		if err == concourse.ErrUnauthorized {
-			fmt.Fprintln(ui.Stderr, "not authorized. run the following to log in:")
-			fmt.Fprintln(ui.Stderr, "")
-			fmt.Fprintln(ui.Stderr, "    "+ui.Embolden("fly -t %s login", commands.Fly.Target))
-			fmt.Fprintln(ui.Stderr, "")
+			fmt.Fprintf(ui.Stderr, unauthorizedErrorTemplate, ui.Embolden("fly -t %s login", commands.Fly.Target))
 		} else if err == rc.ErrNoTargetSpecified {
-			fmt.Fprintln(ui.Stderr, "no target specified. specify the target with "+ui.Embolden("-t")+" or log in like so:")
-			fmt.Fprintln(ui.Stderr, "")
-			fmt.Fprintln(ui.Stderr, "    "+ui.Embolden("fly -t (alias) login -c (concourse url)"))
-			fmt.Fprintln(ui.Stderr, "")
+			fmt.Fprintf(ui.Stderr, noTargetSpecifiedErrorTemplate, ui.Embolden("fly -t (alias) login -c (concourse url)"))
 		} else if versionErr, ok := err.(rc.ErrVersionMismatch); ok {
 			fmt.Fprintln(ui.Stderr, versionErr.Error())
 			fmt.Fprintln(ui.Stderr, ui.WarningColor("cowardly refusing to run due to significant version discrepancy"))
 		} else if netErr, ok := err.(net.Error); ok {
-			fmt.Fprintf(ui.Stderr, "could not reach the Concourse server called %s:\n", ui.Embolden("%s", commands.Fly.Target))
-
-			fmt.Fprintln(ui.Stderr, "")
-			fmt.Fprintln(ui.Stderr, "    "+ui.Embolden("%s", netErr))
-			fmt.Fprintln(ui.Stderr, "")
-			fmt.Fprintln(ui.Stderr, "is the targeted Concourse running? better go catch it lol")
+			fmt.Fprintf(ui.Stderr, couldNotReachConcourse, ui.Embolden("%s", commands.Fly.Target), ui.Embolden("%s", netErr))
 		} else if err == commands.ErrShowHelpMessage {
-			helpParser := flags.NewParser(&commands.Fly, flags.HelpFlag)
-			helpParser.NamespaceDelimiter = "-"
+			helpParser.ParseArgs([]string{"-h"})
+			helpParser.WriteHelp(os.Stdout)
+			os.Exit(0)
+		} else if flagsErr, ok := err.(*flags.Error); ok && flagsErr.Type == flags.ErrCommandRequired {
 			helpParser.ParseArgs([]string{"-h"})
 			helpParser.WriteHelp(os.Stdout)
 			os.Exit(0)
@@ -75,3 +69,25 @@ func main() {
 		os.Exit(1)
 	}
 }
+
+var unauthorizedErrorTemplate = `
+not authorized. run the following to log in:
+
+    %s
+
+`
+
+var noTargetSpecifiedErrorTemplate = `
+no target specified. specify the target with -t or log in like so:
+
+    %s
+
+`
+
+var couldNotReachConcourse = `
+could not reach the Concourse server called %s:
+
+    %s
+
+is the targeted Concourse running? better go catch it lol
+`


### PR DESCRIPTION
@jwfriese recently started using fly and found it really confusing that it does not just print the help when you execute with no args. Made this a little nicer for new people.

Also, templates have been broken apart but still manage to print errors the same way.

💥 