### PR TITLE
Added token login to fly

### DIFF
--- a/commands/login.go
+++ b/commands/login.go
@@ -9,6 +9,7 @@ import (
 
 	"net"
 
+	"crypto/tls"
 	"github.com/concourse/atc"
 	"github.com/concourse/fly/rc"
 	"github.com/concourse/go-concourse/concourse"
@@ -21,6 +22,7 @@ type LoginCommand struct {
 	Username string       `short:"u" long:"username" description:"Username for basic auth"`
 	Password string       `short:"p" long:"password" description:"Password for basic auth"`
 	TeamName string       `short:"n" long:"team-name" description:"Team to authenticate with"`
+	Token    string       `long:"token" description:"Token for OAuth login"`
 	CACert   atc.PathFlag `long:"ca-cert" description:"Path to Concourse PEM-encoded CA certificate file."`
 }
 
@@ -182,35 +184,50 @@ func (command *LoginCommand) loginWith(
 	case atc.AuthTypeOAuth:
 		var tokenStr string
 
-		stdinChannel := make(chan string)
-		tokenChannel := make(chan string)
-		errorChannel := make(chan error)
-		portChannel := make(chan string)
+		if command.Token != "" {
+			fmt.Println("Yeah, who needs the web auth flow anyway? Token FTW!")
 
-		go listenForTokenCallback(tokenChannel, errorChannel, portChannel, targetUrl)
+			tradedToken, err := usePersonalToken(method.TokenURL, command.Token, command.Insecure)
 
-		port := <-portChannel
+			if err != nil {
+				return nil, err
+			}
 
-		fmt.Println("navigate to the following URL in your browser:")
-		fmt.Println("")
-		fmt.Printf("    %s&fly_local_port=%s\n", method.AuthURL, port)
-		fmt.Println("")
+			segments := strings.SplitN(tradedToken, " ", 2)
 
-		go waitForTokenInput(stdinChannel, errorChannel)
+			token.Type = segments[0]
+			token.Value = segments[1]
 
-		select {
-		case tokenStrMsg := <-tokenChannel:
-			tokenStr = tokenStrMsg
-		case tokenStrMsg := <-stdinChannel:
-			tokenStr = tokenStrMsg
-		case errorMsg := <-errorChannel:
-			return nil, errorMsg
+		} else {
+			stdinChannel := make(chan string)
+			tokenChannel := make(chan string)
+			errorChannel := make(chan error)
+			portChannel := make(chan string)
+
+			go listenForTokenCallback(tokenChannel, errorChannel, portChannel, targetUrl)
+
+			port := <-portChannel
+
+			fmt.Println("navigate to the following URL in your browser:")
+			fmt.Println("")
+			fmt.Printf("    %s&fly_local_port=%s\n", method.AuthURL, port)
+			fmt.Println("")
+
+			go waitForTokenInput(stdinChannel, errorChannel, method.TokenURL, command.Insecure)
+
+			select {
+			case tokenStrMsg := <-tokenChannel:
+				tokenStr = tokenStrMsg
+			case tokenStrMsg := <-stdinChannel:
+				tokenStr = tokenStrMsg
+			case errorMsg := <-errorChannel:
+				return nil, errorMsg
+			}
+			segments := strings.SplitN(tokenStr, " ", 2)
+
+			token.Type = segments[0]
+			token.Value = segments[1]
 		}
-
-		segments := strings.SplitN(tokenStr, " ", 2)
-
-		token.Type = segments[0]
-		token.Value = segments[1]
 
 	case atc.AuthTypeBasic:
 		var username string
@@ -257,14 +274,27 @@ func (command *LoginCommand) loginWith(
 	return &token, nil
 }
 
-func waitForTokenInput(tokenChannel chan string, errorChannel chan error) {
+func waitForTokenInput(tokenChannel chan string, errorChannel chan error, tokenUrl string, insecure bool) {
 	for {
-		fmt.Printf("or enter token manually: ")
+		fmt.Printf("or enter one of the following token types:\n")
+		fmt.Printf("    - Personal access token (e.g. '1234567890')\n")
+		fmt.Printf("    - Bearer token (e.g. 'Bearer 1234567890')\n\n")
+		fmt.Printf("Token: ")
 
 		var tokenType string
 		var tokenValue string
 		count, err := fmt.Scanf("%s %s", &tokenType, &tokenValue)
 		if err != nil {
+			if count == 1 {
+				// assume it is a token...
+				tradedToken, err := usePersonalToken(tokenUrl, tokenType, insecure)
+				if err != nil {
+					fmt.Println(err.Error())
+					continue
+				}
+				tokenChannel <- tradedToken
+				break
+			}
 			if count != 2 {
 				fmt.Println("token must be of the format 'TYPE VALUE', e.g. 'Bearer ...'")
 				continue
@@ -277,6 +307,30 @@ func waitForTokenInput(tokenChannel chan string, errorChannel chan error) {
 		tokenChannel <- tokenType + " " + tokenValue
 		break
 	}
+}
+
+func usePersonalToken(tokenUrl string, token string, insecure bool) (string, error) {
+	httpTransport := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
+	}
+	client := &http.Client{Transport: httpTransport}
+
+	response, err := client.Post(tokenUrl, "text/plain", strings.NewReader(token))
+
+	if err != nil {
+		return "", err
+	}
+	defer response.Body.Close()
+
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return "", err
+	}
+
+	if response.StatusCode != 200 {
+		return "", errors.New(string(body))
+	}
+	return string(body), nil
 }
 
 func (command *LoginCommand) saveTarget(url string, token *rc.TargetToken, caCert string) error {

--- a/integration/login_test.go
+++ b/integration/login_test.go
@@ -356,11 +356,13 @@ var _ = Describe("login Command", func() {
 								Type:        atc.AuthTypeOAuth,
 								DisplayName: "OAuth Type 1",
 								AuthURL:     "https://example.com/auth/oauth-1?team_name=main",
+								TokenURL:    fmt.Sprintf("%s/auth/oauth-1/token?team_name=main", loginATCServer.URL()),
 							},
 							{
 								Type:        atc.AuthTypeOAuth,
 								DisplayName: "OAuth Type 2",
 								AuthURL:     "https://example.com/auth/oauth-2?team_name=main",
+								TokenURL:    fmt.Sprintf("%s/auth/oauth-2/token?team_name=main", loginATCServer.URL()),
 							},
 						}),
 					),
@@ -405,6 +407,70 @@ var _ = Describe("login Command", func() {
 					<-sess.Exited
 					Expect(sess.ExitCode()).To(Equal(0))
 
+					loginATCServer.AppendHandlers(
+						infoHandler(),
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("GET", "/api/v1/teams/main/pipelines"),
+							ghttp.VerifyHeaderKV("Authorization", "Bearer the-token"),
+							ghttp.RespondWithJSONEncoded(200, []atc.Pipeline{
+								{Name: "pipeline-1"},
+							}),
+						),
+					)
+
+					otherCmd := exec.Command(flyPath, "-t", "some-target", "pipelines")
+
+					sess, err = gexec.Start(otherCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+
+					<-sess.Exited
+
+					Expect(sess).To(gbytes.Say("pipeline-1"))
+
+					Expect(sess.ExitCode()).To(Equal(0))
+
+				})
+
+				It("logs into fly with a personal access token", func() {
+
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(sess.Out).Should(gbytes.Say("1. Basic"))
+					Eventually(sess.Out).Should(gbytes.Say("2. OAuth Type 1"))
+					Eventually(sess.Out).Should(gbytes.Say("3. OAuth Type 2"))
+					Eventually(sess.Out).Should(gbytes.Say("choose an auth method: "))
+
+					_, err = fmt.Fprintf(stdin, "3\n")
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(sess.Out).Should(gbytes.Say("navigate to the following URL in your browser:"))
+					Eventually(sess.Out).Should(gbytes.Say(`.*`))
+					Eventually(sess.Out).Should(gbytes.Say(`or enter one of the following token types:\n`))
+					Eventually(sess.Out).Should(gbytes.Say(`    - Personal access token \(e.g. '1234567890'\)\n`))
+					Eventually(sess.Out).Should(gbytes.Say(`    - Bearer token \(e.g. 'Bearer 1234567890'\)\n`))
+					Eventually(sess.Out).Should(gbytes.Say(`\n`))
+					Eventually(sess.Out).Should(gbytes.Say(`Token: `))
+
+					loginATCServer.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("POST", "/auth/oauth-2/token"),
+							ghttp.VerifyBody([]byte("11223344556677889900")),
+							ghttp.RespondWith(200, "Bearer the-token"),
+						),
+					)
+
+					_, err = fmt.Fprintf(stdin, "11223344556677889900\n")
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(sess.Out).Should(gbytes.Say("target saved"))
+
+					err = stdin.Close()
+					Expect(err).NotTo(HaveOccurred())
+
+					<-sess.Exited
+					Expect(sess.ExitCode()).To(Equal(0))
+l
 					loginATCServer.AppendHandlers(
 						infoHandler(),
 						ghttp.CombineHandlers(
@@ -685,6 +751,72 @@ var _ = Describe("login Command", func() {
 			})
 		})
 
+		Context("when only one oauth method is returned from the API", func() {
+			BeforeEach(func() {
+				loginATCServer.AppendHandlers(
+					infoHandler(),
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/api/v1/teams/main/auth/methods"),
+						ghttp.RespondWithJSONEncoded(200, []atc.AuthMethod{
+							{
+								Type:        atc.AuthTypeOAuth,
+								DisplayName: "OAuth Type 1",
+								AuthURL:     "https://example.com/auth/oauth-1?team_name=main",
+								TokenURL:    fmt.Sprintf("%s/auth/oauth-1/token?team_name=main", loginATCServer.URL()),
+							},
+						}),
+					),
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("POST", "/auth/oauth-1/token"),
+						ghttp.VerifyBody([]byte("11223344556677889900")),
+						ghttp.RespondWith(200, "Bearer the-token"),
+					),
+				)
+			})
+
+			It("logs in with a personal access token", func() {
+
+				flyCmd = exec.Command(flyPath, "-t", "some-target", "login", "-c", loginATCServer.URL(), "--token", "11223344556677889900")
+
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(sess.Out).Should(gbytes.Say(`logging in to team 'main'\n\n`))
+				Eventually(sess.Out).Should(gbytes.Say(`Yeah, who needs the web auth flow anyway\? Token FTW!\n\n`))
+				Eventually(sess.Out).Should(gbytes.Say(`target saved`))
+
+				err = stdin.Close()
+				Expect(err).NotTo(HaveOccurred())
+
+				<-sess.Exited
+				Expect(sess.ExitCode()).To(Equal(0))
+
+				loginATCServer.AppendHandlers(
+					infoHandler(),
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/api/v1/teams/main/pipelines"),
+						ghttp.VerifyHeaderKV("Authorization", "Bearer the-token"),
+						ghttp.RespondWithJSONEncoded(200, []atc.Pipeline{
+							{Name: "pipeline-1"},
+						}),
+					),
+				)
+
+				otherCmd := exec.Command(flyPath, "-t", "some-target", "pipelines")
+
+				sess, err = gexec.Start(otherCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				<-sess.Exited
+
+				Expect(sess).To(gbytes.Say("pipeline-1"))
+
+				Expect(sess.ExitCode()).To(Equal(0))
+
+			})
+
+		})
+
 		Context("when only one auth method is returned from the API", func() {
 			BeforeEach(func() {
 				loginATCServer.AppendHandlers(
@@ -734,6 +866,7 @@ var _ = Describe("login Command", func() {
 				<-sess.Exited
 				Expect(sess.ExitCode()).To(Equal(0))
 			})
+
 		})
 
 		Context("when no auth methods are returned from the API", func() {


### PR DESCRIPTION
@vito 
@jtarchie 
@chendrix 

Please review & merge.
This is linked to https://github.com/concourse/atc/pull/184 which needs to be merged first for fly to support token login.

This PR enables the user to do the following:
```
./fly login -c http://localhost:8080 -t main -n openCloak --token c8294f0dd721dbba7cf39a9ea882eed1273ab8ca
logging in to team 'openCloak'

Yeah, who needs the web auth flow anyway? Token FTW!

target saved
```
or 

```
 ./fly login -c http://localhost:8080 -t main -n openCloak
logging in to team 'openCloak'

navigate to the following URL in your browser:

    http://127.0.0.1:8080/auth/github?team_name=openCloak&fly_local_port=56424

or enter one of the following token types:
    - Personal access token (e.g. 1233456789)
    - Bearer token (e.g. 'Bearer 1234567890'

Token: a5ea7763eb91fb0863cc8335879be34b7f8691fe

target saved
```

This also works with multiple auth methods. 
Please note the failing tests because the atc PR is not merged yet.