### PR TITLE
Fix improper usages of FailWithErrorf

### DIFF
--- a/commands/internal/setpipelinehelpers/atc_config.go
+++ b/commands/internal/setpipelinehelpers/atc_config.go
@@ -106,13 +106,13 @@ func (atcConfig ATCConfig) newConfig(configPath atc.PathFlag, templateVariablesF
 	if temp.Present(evaluatedConfig) {
 		evaluatedConfig, err = atcConfig.resolveDeprecatedTemplateStyle(evaluatedConfig, paramPayloads, templateVariables, yamlTemplateVariables)
 		if err != nil {
-			displayhelpers.FailWithErrorf("could not resolve old-style template vars: %s", err)
+			displayhelpers.FailWithErrorf("could not resolve old-style template vars", err)
 		}
 	}
 
 	evaluatedConfig, err = atcConfig.resolveTemplates(evaluatedConfig, paramPayloads, templateVariables, yamlTemplateVariables)
 	if err != nil {
-		displayhelpers.Failf("could not resolve template vars: %s", err)
+		displayhelpers.FailWithErrorf("could not resolve template vars", err)
 	}
 
 	return evaluatedConfig

--- a/commands/sync.go
+++ b/commands/sync.go
@@ -35,7 +35,7 @@ func (command *SyncCommand) Execute(args []string) error {
 	err = updateOptions.CheckPermissions()
 	if err != nil {
 
-		displayhelpers.FailWithErrorf("update failed:", err)
+		displayhelpers.FailWithErrorf("update failed", err)
 	}
 
 	client := target.Client()
@@ -55,7 +55,7 @@ func (command *SyncCommand) Execute(args []string) error {
 
 	err = update.Apply(reader, updateOptions)
 	if err != nil {
-		displayhelpers.FailWithErrorf("update failed:", err)
+		displayhelpers.FailWithErrorf("update failed", err)
 	}
 
 	return nil


### PR DESCRIPTION
* FailWithErrorf and only an error should not have any format declarations
* FailWithErrorf should never be given a trailing colon (`:`)

This fixes an issue where missing params returns a Golang `%!s(MISSING)` error:

    could not resolve old-style template vars: %!s(MISSING): 1 errors occurred:
    
    * unbound variable in template: 'some_placeholder'

I also noticed some usages that added an extra colon unnecessarily, so I fixed those as well.