### PR TITLE
Add missing GitLab to fly set-team prompt

### DIFF
--- a/commands/set_team.go
+++ b/commands/set_team.go
@@ -39,6 +39,7 @@ func (command *SetTeamCommand) Execute([]string) error {
 	fmt.Println("Team Name:", command.TeamName)
 	fmt.Println("Basic Auth:", authMethodStatusDescription(command.Authentication.BasicAuth.IsConfigured()))
 	fmt.Println("GitHub Auth:", authMethodStatusDescription(command.ProviderAuth["github"].IsConfigured()))
+	fmt.Println("GitLab Auth:", authMethodStatusDescription(command.ProviderAuth["gitlab"].IsConfigured()))
 	fmt.Println("UAA Auth:", authMethodStatusDescription(command.ProviderAuth["uaa"].IsConfigured()))
 	fmt.Println("Generic OAuth:", authMethodStatusDescription(command.ProviderAuth["oauth"].IsConfigured()))
 


### PR DESCRIPTION
As part of PR https://github.com/concourse/fly/pull/179: "Fly and GitLab OAuth integration" I noticed I missed adding the GitLab entry for the set-team prompt.

If someone is setting GitLab oauth with `fly set-team`, the prompt does not show GitLab which is uber confusing

For more information, please see the already merged original PR: https://github.com/concourse/fly/pull/179