### PR TITLE
fixes color support for fly cli on windows 10

### DIFF
--- a/commands/builds.go
+++ b/commands/builds.go
@@ -12,7 +12,6 @@ import (
 	"github.com/concourse/fly/ui"
 	"github.com/concourse/go-concourse/concourse"
 	"github.com/fatih/color"
-	colorable "github.com/mattn/go-colorable"
 )
 
 const timeDateLayout = "2006-01-02@15:04:05-0700"
@@ -122,7 +121,7 @@ func (command *BuildsCommand) Execute([]string) error {
 		})
 	}
 
-	return table.Render(colorable.NewColorableStdout(), Fly.PrintTableHeaders)
+	return table.Render(color.Output, Fly.PrintTableHeaders)
 }
 
 func populateTimeCells(startTime time.Time, endTime time.Time) (ui.TableCell, ui.TableCell, ui.TableCell) {

--- a/commands/builds.go
+++ b/commands/builds.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/concourse/fly/ui"
 	"github.com/concourse/go-concourse/concourse"
 	"github.com/fatih/color"
+	colorable "github.com/mattn/go-colorable"
 )
 
 const timeDateLayout = "2006-01-02@15:04:05-0700"
@@ -122,7 +122,7 @@ func (command *BuildsCommand) Execute([]string) error {
 		})
 	}
 
-	return table.Render(os.Stdout, Fly.PrintTableHeaders)
+	return table.Render(colorable.NewColorableStdout(), Fly.PrintTableHeaders)
 }
 
 func populateTimeCells(startTime time.Time, endTime time.Time) (ui.TableCell, ui.TableCell, ui.TableCell) {

--- a/commands/containers.go
+++ b/commands/containers.go
@@ -1,13 +1,13 @@
 package commands
 
 import (
-	"os"
 	"sort"
 	"strconv"
 
 	"github.com/concourse/fly/rc"
 	"github.com/concourse/fly/ui"
 	"github.com/fatih/color"
+	colorable "github.com/mattn/go-colorable"
 )
 
 type ContainersCommand struct{}
@@ -60,7 +60,7 @@ func (command *ContainersCommand) Execute([]string) error {
 
 	sort.Sort(table.Data)
 
-	return table.Render(os.Stdout, Fly.PrintTableHeaders)
+	return table.Render(colorable.NewColorableStdout(), Fly.PrintTableHeaders)
 }
 
 func buildIDOrNone(id int) ui.TableCell {

--- a/commands/containers.go
+++ b/commands/containers.go
@@ -7,7 +7,6 @@ import (
 	"github.com/concourse/fly/rc"
 	"github.com/concourse/fly/ui"
 	"github.com/fatih/color"
-	colorable "github.com/mattn/go-colorable"
 )
 
 type ContainersCommand struct{}
@@ -60,7 +59,7 @@ func (command *ContainersCommand) Execute([]string) error {
 
 	sort.Sort(table.Data)
 
-	return table.Render(colorable.NewColorableStdout(), Fly.PrintTableHeaders)
+	return table.Render(color.Output, Fly.PrintTableHeaders)
 }
 
 func buildIDOrNone(id int) ui.TableCell {

--- a/commands/execute.go
+++ b/commands/execute.go
@@ -15,6 +15,7 @@ import (
 	"github.com/concourse/fly/rc"
 	"github.com/concourse/fly/ui"
 	"github.com/concourse/go-concourse/concourse"
+	colorable "github.com/mattn/go-colorable"
 )
 
 type ExecuteCommand struct {
@@ -127,7 +128,7 @@ func (command *ExecuteCommand) Execute(args []string) error {
 		return err
 	}
 
-	exitCode := eventstream.Render(os.Stdout, eventSource)
+	exitCode := eventstream.Render(colorable.NewColorableStdout(), eventSource)
 	eventSource.Close()
 
 	<-inputChan

--- a/commands/execute.go
+++ b/commands/execute.go
@@ -15,7 +15,7 @@ import (
 	"github.com/concourse/fly/rc"
 	"github.com/concourse/fly/ui"
 	"github.com/concourse/go-concourse/concourse"
-	colorable "github.com/mattn/go-colorable"
+	"github.com/fatih/color"
 )
 
 type ExecuteCommand struct {
@@ -128,7 +128,7 @@ func (command *ExecuteCommand) Execute(args []string) error {
 		return err
 	}
 
-	exitCode := eventstream.Render(colorable.NewColorableStdout(), eventSource)
+	exitCode := eventstream.Render(color.Output, eventSource)
 	eventSource.Close()
 
 	<-inputChan

--- a/commands/format_pipeline.go
+++ b/commands/format_pipeline.go
@@ -11,6 +11,7 @@ import (
 	"github.com/concourse/atc"
 	"github.com/concourse/fly/commands/internal/displayhelpers"
 	yamlpatch "github.com/krishicks/yaml-patch"
+	colorable "github.com/mattn/go-colorable"
 )
 
 type FormatPipelineCommand struct {
@@ -53,7 +54,7 @@ func (command *FormatPipelineCommand) Execute(args []string) error {
 				displayhelpers.FailWithErrorf("could not write formatted config to %s", err, command.Config)
 			}
 		} else {
-			_, err = fmt.Fprint(os.Stdout, string(unwrappedConfigBytes))
+			_, err = fmt.Fprint(colorable.NewColorableStdout(), string(unwrappedConfigBytes))
 			if err != nil {
 				displayhelpers.FailWithErrorf("could not write formatted config to stdout", err)
 			}

--- a/commands/format_pipeline.go
+++ b/commands/format_pipeline.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/concourse/atc"
 	"github.com/concourse/fly/commands/internal/displayhelpers"
+	"github.com/fatih/color"
 	yamlpatch "github.com/krishicks/yaml-patch"
-	colorable "github.com/mattn/go-colorable"
 )
 
 type FormatPipelineCommand struct {
@@ -54,7 +54,7 @@ func (command *FormatPipelineCommand) Execute(args []string) error {
 				displayhelpers.FailWithErrorf("could not write formatted config to %s", err, command.Config)
 			}
 		} else {
-			_, err = fmt.Fprint(colorable.NewColorableStdout(), string(unwrappedConfigBytes))
+			_, err = fmt.Fprint(color.Output, string(unwrappedConfigBytes))
 			if err != nil {
 				displayhelpers.FailWithErrorf("could not write formatted config to stdout", err)
 			}

--- a/commands/hijack.go
+++ b/commands/hijack.go
@@ -16,6 +16,7 @@ import (
 	"github.com/concourse/fly/pty"
 	"github.com/concourse/fly/rc"
 	"github.com/concourse/go-concourse/concourse"
+	colorable "github.com/mattn/go-colorable"
 	"github.com/tedsuo/rata"
 	"github.com/vito/go-interact/interact"
 )
@@ -141,7 +142,7 @@ func (command *HijackCommand) Execute([]string) error {
 
 		io := hijacker.ProcessIO{
 			In:  in,
-			Out: os.Stdout,
+			Out: colorable.NewColorableStdout(),
 			Err: os.Stderr,
 		}
 

--- a/commands/hijack.go
+++ b/commands/hijack.go
@@ -16,7 +16,7 @@ import (
 	"github.com/concourse/fly/pty"
 	"github.com/concourse/fly/rc"
 	"github.com/concourse/go-concourse/concourse"
-	colorable "github.com/mattn/go-colorable"
+	"github.com/fatih/color"
 	"github.com/tedsuo/rata"
 	"github.com/vito/go-interact/interact"
 )
@@ -142,7 +142,7 @@ func (command *HijackCommand) Execute([]string) error {
 
 		io := hijacker.ProcessIO{
 			In:  in,
-			Out: colorable.NewColorableStdout(),
+			Out: color.Output,
 			Err: os.Stderr,
 		}
 

--- a/commands/internal/setpipelinehelpers/atc_config.go
+++ b/commands/internal/setpipelinehelpers/atc_config.go
@@ -3,7 +3,6 @@ package setpipelinehelpers
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 
 	yaml "gopkg.in/yaml.v2"
 
@@ -15,6 +14,7 @@ import (
 	temp "github.com/concourse/fly/template"
 	"github.com/concourse/fly/ui"
 	"github.com/concourse/go-concourse/concourse"
+	colorable "github.com/mattn/go-colorable"
 	"github.com/onsi/gomega/gexec"
 	"github.com/tedsuo/rata"
 	"github.com/vito/go-interact/interact"
@@ -276,7 +276,7 @@ func (atcConfig ATCConfig) showHelpfulMessage(created bool, updated bool) {
 }
 
 func diff(existingConfig atc.Config, newConfig atc.Config) {
-	indent := gexec.NewPrefixedWriter("  ", os.Stdout)
+	indent := gexec.NewPrefixedWriter("  ", colorable.NewColorableStdout())
 
 	groupDiffs := diffIndices(GroupIndex(existingConfig.Groups), GroupIndex(newConfig.Groups))
 	if len(groupDiffs) > 0 {

--- a/commands/internal/setpipelinehelpers/atc_config.go
+++ b/commands/internal/setpipelinehelpers/atc_config.go
@@ -14,7 +14,7 @@ import (
 	temp "github.com/concourse/fly/template"
 	"github.com/concourse/fly/ui"
 	"github.com/concourse/go-concourse/concourse"
-	colorable "github.com/mattn/go-colorable"
+	"github.com/fatih/color"
 	"github.com/onsi/gomega/gexec"
 	"github.com/tedsuo/rata"
 	"github.com/vito/go-interact/interact"
@@ -276,7 +276,7 @@ func (atcConfig ATCConfig) showHelpfulMessage(created bool, updated bool) {
 }
 
 func diff(existingConfig atc.Config, newConfig atc.Config) {
-	indent := gexec.NewPrefixedWriter("  ", colorable.NewColorableStdout())
+	indent := gexec.NewPrefixedWriter("  ", color.Output)
 
 	groupDiffs := diffIndices(GroupIndex(existingConfig.Groups), GroupIndex(newConfig.Groups))
 	if len(groupDiffs) > 0 {

--- a/commands/jobs.go
+++ b/commands/jobs.go
@@ -5,7 +5,6 @@ import (
 	"github.com/concourse/fly/rc"
 	"github.com/concourse/fly/ui"
 	"github.com/fatih/color"
-	colorable "github.com/mattn/go-colorable"
 )
 
 type JobsCommand struct {
@@ -80,5 +79,5 @@ func (command *JobsCommand) Execute([]string) error {
 		table.Data = append(table.Data, row)
 	}
 
-	return table.Render(colorable.NewColorableStdout(), Fly.PrintTableHeaders)
+	return table.Render(color.Output, Fly.PrintTableHeaders)
 }

--- a/commands/jobs.go
+++ b/commands/jobs.go
@@ -1,12 +1,11 @@
 package commands
 
 import (
-	"os"
-
 	"github.com/concourse/atc"
 	"github.com/concourse/fly/rc"
 	"github.com/concourse/fly/ui"
 	"github.com/fatih/color"
+	colorable "github.com/mattn/go-colorable"
 )
 
 type JobsCommand struct {
@@ -81,5 +80,5 @@ func (command *JobsCommand) Execute([]string) error {
 		table.Data = append(table.Data, row)
 	}
 
-	return table.Render(os.Stdout, Fly.PrintTableHeaders)
+	return table.Render(colorable.NewColorableStdout(), Fly.PrintTableHeaders)
 }

--- a/commands/pipelines.go
+++ b/commands/pipelines.go
@@ -1,12 +1,11 @@
 package commands
 
 import (
-	"os"
-
 	"github.com/concourse/atc"
 	"github.com/concourse/fly/rc"
 	"github.com/concourse/fly/ui"
 	"github.com/fatih/color"
+	colorable "github.com/mattn/go-colorable"
 )
 
 type PipelinesCommand struct {
@@ -71,5 +70,5 @@ func (command *PipelinesCommand) Execute([]string) error {
 		table.Data = append(table.Data, row)
 	}
 
-	return table.Render(os.Stdout, Fly.PrintTableHeaders)
+	return table.Render(colorable.NewColorableStdout(), Fly.PrintTableHeaders)
 }

--- a/commands/pipelines.go
+++ b/commands/pipelines.go
@@ -5,7 +5,6 @@ import (
 	"github.com/concourse/fly/rc"
 	"github.com/concourse/fly/ui"
 	"github.com/fatih/color"
-	colorable "github.com/mattn/go-colorable"
 )
 
 type PipelinesCommand struct {
@@ -70,5 +69,5 @@ func (command *PipelinesCommand) Execute([]string) error {
 		table.Data = append(table.Data, row)
 	}
 
-	return table.Render(colorable.NewColorableStdout(), Fly.PrintTableHeaders)
+	return table.Render(color.Output, Fly.PrintTableHeaders)
 }

--- a/commands/targets.go
+++ b/commands/targets.go
@@ -9,7 +9,6 @@ import (
 	"github.com/concourse/fly/ui"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/fatih/color"
-	colorable "github.com/mattn/go-colorable"
 )
 
 type TargetsCommand struct{}
@@ -44,7 +43,7 @@ func (command *TargetsCommand) Execute([]string) error {
 
 	sort.Sort(table.Data)
 
-	return table.Render(colorable.NewColorableStdout(), Fly.PrintTableHeaders)
+	return table.Render(color.Output, Fly.PrintTableHeaders)
 }
 
 func GetExpirationFromString(token *rc.TargetToken) string {

--- a/commands/targets.go
+++ b/commands/targets.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"os"
 	"sort"
 	"strconv"
 	"time"
@@ -10,6 +9,7 @@ import (
 	"github.com/concourse/fly/ui"
 	"github.com/dgrijalva/jwt-go"
 	"github.com/fatih/color"
+	colorable "github.com/mattn/go-colorable"
 )
 
 type TargetsCommand struct{}
@@ -44,7 +44,7 @@ func (command *TargetsCommand) Execute([]string) error {
 
 	sort.Sort(table.Data)
 
-	return table.Render(os.Stdout, Fly.PrintTableHeaders)
+	return table.Render(colorable.NewColorableStdout(), Fly.PrintTableHeaders)
 }
 
 func GetExpirationFromString(token *rc.TargetToken) string {

--- a/commands/teams.go
+++ b/commands/teams.go
@@ -6,7 +6,6 @@ import (
 	"github.com/concourse/fly/rc"
 	"github.com/concourse/fly/ui"
 	"github.com/fatih/color"
-	colorable "github.com/mattn/go-colorable"
 )
 
 type TeamsCommand struct{}
@@ -43,5 +42,5 @@ func (command *TeamsCommand) Execute([]string) error {
 
 	sort.Sort(table.Data)
 
-	return table.Render(colorable.NewColorableStdout(), Fly.PrintTableHeaders)
+	return table.Render(color.Output, Fly.PrintTableHeaders)
 }

--- a/commands/teams.go
+++ b/commands/teams.go
@@ -1,12 +1,12 @@
 package commands
 
 import (
-	"os"
 	"sort"
 
 	"github.com/concourse/fly/rc"
 	"github.com/concourse/fly/ui"
 	"github.com/fatih/color"
+	colorable "github.com/mattn/go-colorable"
 )
 
 type TeamsCommand struct{}
@@ -43,5 +43,5 @@ func (command *TeamsCommand) Execute([]string) error {
 
 	sort.Sort(table.Data)
 
-	return table.Render(os.Stdout, Fly.PrintTableHeaders)
+	return table.Render(colorable.NewColorableStdout(), Fly.PrintTableHeaders)
 }

--- a/commands/trigger_job.go
+++ b/commands/trigger_job.go
@@ -10,7 +10,7 @@ import (
 	"github.com/concourse/fly/eventstream"
 	"github.com/concourse/fly/rc"
 	"github.com/concourse/fly/ui"
-	colorable "github.com/mattn/go-colorable"
+	"github.com/fatih/color"
 )
 
 type TriggerJobCommand struct {
@@ -56,7 +56,7 @@ func (command *TriggerJobCommand) Execute(args []string) error {
 			return err
 		}
 
-		exitCode := eventstream.Render(colorable.NewColorableStdout(), eventSource)
+		exitCode := eventstream.Render(color.Output, eventSource)
 
 		eventSource.Close()
 

--- a/commands/trigger_job.go
+++ b/commands/trigger_job.go
@@ -10,6 +10,7 @@ import (
 	"github.com/concourse/fly/eventstream"
 	"github.com/concourse/fly/rc"
 	"github.com/concourse/fly/ui"
+	colorable "github.com/mattn/go-colorable"
 )
 
 type TriggerJobCommand struct {
@@ -55,7 +56,7 @@ func (command *TriggerJobCommand) Execute(args []string) error {
 			return err
 		}
 
-		exitCode := eventstream.Render(os.Stdout, eventSource)
+		exitCode := eventstream.Render(colorable.NewColorableStdout(), eventSource)
 
 		eventSource.Close()
 

--- a/commands/volumes.go
+++ b/commands/volumes.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 	"time"
@@ -13,6 +12,7 @@ import (
 	"github.com/concourse/fly/rc"
 	"github.com/concourse/fly/ui"
 	"github.com/fatih/color"
+	colorable "github.com/mattn/go-colorable"
 )
 
 type VolumesCommand struct {
@@ -57,7 +57,7 @@ func (command *VolumesCommand) Execute([]string) error {
 		table.Data = append(table.Data, row)
 	}
 
-	return table.Render(os.Stdout, Fly.PrintTableHeaders)
+	return table.Render(colorable.NewColorableStdout(), Fly.PrintTableHeaders)
 }
 
 func (command *VolumesCommand) volumeIdentifier(volume atc.Volume) string {

--- a/commands/volumes.go
+++ b/commands/volumes.go
@@ -12,7 +12,6 @@ import (
 	"github.com/concourse/fly/rc"
 	"github.com/concourse/fly/ui"
 	"github.com/fatih/color"
-	colorable "github.com/mattn/go-colorable"
 )
 
 type VolumesCommand struct {
@@ -57,7 +56,7 @@ func (command *VolumesCommand) Execute([]string) error {
 		table.Data = append(table.Data, row)
 	}
 
-	return table.Render(colorable.NewColorableStdout(), Fly.PrintTableHeaders)
+	return table.Render(color.Output, Fly.PrintTableHeaders)
 }
 
 func (command *VolumesCommand) volumeIdentifier(volume atc.Volume) string {

--- a/commands/watch.go
+++ b/commands/watch.go
@@ -8,7 +8,7 @@ import (
 	"github.com/concourse/fly/commands/internal/flaghelpers"
 	"github.com/concourse/fly/eventstream"
 	"github.com/concourse/fly/rc"
-	colorable "github.com/mattn/go-colorable"
+	"github.com/fatih/color"
 )
 
 type WatchCommand struct {
@@ -48,7 +48,7 @@ func (command *WatchCommand) Execute(args []string) error {
 		return err
 	}
 
-	exitCode := eventstream.Render(colorable.NewColorableStdout(), eventSource)
+	exitCode := eventstream.Render(color.Output, eventSource)
 
 	eventSource.Close()
 

--- a/commands/watch.go
+++ b/commands/watch.go
@@ -8,6 +8,7 @@ import (
 	"github.com/concourse/fly/commands/internal/flaghelpers"
 	"github.com/concourse/fly/eventstream"
 	"github.com/concourse/fly/rc"
+	colorable "github.com/mattn/go-colorable"
 )
 
 type WatchCommand struct {
@@ -47,7 +48,7 @@ func (command *WatchCommand) Execute(args []string) error {
 		return err
 	}
 
-	exitCode := eventstream.Render(os.Stdout, eventSource)
+	exitCode := eventstream.Render(colorable.NewColorableStdout(), eventSource)
 
 	eventSource.Close()
 

--- a/commands/workers.go
+++ b/commands/workers.go
@@ -10,7 +10,6 @@ import (
 	"github.com/concourse/fly/rc"
 	"github.com/concourse/fly/ui"
 	"github.com/fatih/color"
-	colorable "github.com/mattn/go-colorable"
 )
 
 type WorkersCommand struct {
@@ -55,7 +54,7 @@ func (command *WorkersCommand) Execute([]string) error {
 		}
 	}
 
-	stdout := colorable.NewColorableStdout()
+	stdout := color.Output
 	dst, isTTY := ui.ForTTY(stdout)
 	if !isTTY {
 		return command.tableFor(append(append(runningWorkers, outdatedWorkers...), stalledWorkers...)).Render(stdout, Fly.PrintTableHeaders)

--- a/commands/workers.go
+++ b/commands/workers.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -11,6 +10,7 @@ import (
 	"github.com/concourse/fly/rc"
 	"github.com/concourse/fly/ui"
 	"github.com/fatih/color"
+	colorable "github.com/mattn/go-colorable"
 )
 
 type WorkersCommand struct {
@@ -55,12 +55,13 @@ func (command *WorkersCommand) Execute([]string) error {
 		}
 	}
 
-	dst, isTTY := ui.ForTTY(os.Stdout)
+	stdout := colorable.NewColorableStdout()
+	dst, isTTY := ui.ForTTY(stdout)
 	if !isTTY {
-		return command.tableFor(append(append(runningWorkers, outdatedWorkers...), stalledWorkers...)).Render(os.Stdout, Fly.PrintTableHeaders)
+		return command.tableFor(append(append(runningWorkers, outdatedWorkers...), stalledWorkers...)).Render(stdout, Fly.PrintTableHeaders)
 	}
 
-	err = command.tableFor(runningWorkers).Render(os.Stdout, Fly.PrintTableHeaders)
+	err = command.tableFor(runningWorkers).Render(stdout, Fly.PrintTableHeaders)
 	if err != nil {
 		return err
 	}
@@ -76,7 +77,7 @@ func (command *WorkersCommand) Execute([]string) error {
 		fmt.Fprintln(dst, "the following workers need to be updated to version "+ui.Embolden(requiredWorkerVersion)+":")
 		fmt.Fprintln(dst, "")
 
-		err = command.tableFor(outdatedWorkers).Render(os.Stdout, Fly.PrintTableHeaders)
+		err = command.tableFor(outdatedWorkers).Render(stdout, Fly.PrintTableHeaders)
 		if err != nil {
 			return err
 		}
@@ -88,7 +89,7 @@ func (command *WorkersCommand) Execute([]string) error {
 		fmt.Fprintln(dst, "the following workers have not checked in recently:")
 		fmt.Fprintln(dst, "")
 
-		err = command.tableFor(stalledWorkers).Render(os.Stdout, Fly.PrintTableHeaders)
+		err = command.tableFor(stalledWorkers).Render(stdout, Fly.PrintTableHeaders)
 		if err != nil {
 			return err
 		}

--- a/eventstream/renderer.go
+++ b/eventstream/renderer.go
@@ -1,12 +1,11 @@
 package eventstream
 
 import (
-	"os"
-
 	"github.com/concourse/go-concourse/concourse/eventstream"
+	colorable "github.com/mattn/go-colorable"
 	"github.com/vito/go-sse/sse"
 )
 
 func RenderStream(eventSource *sse.EventSource) (int, error) {
-	return Render(os.Stdout, eventstream.NewSSEEventStream(eventSource)), nil
+	return Render(colorable.NewColorableStdout(), eventstream.NewSSEEventStream(eventSource)), nil
 }

--- a/eventstream/renderer.go
+++ b/eventstream/renderer.go
@@ -2,10 +2,10 @@ package eventstream
 
 import (
 	"github.com/concourse/go-concourse/concourse/eventstream"
-	colorable "github.com/mattn/go-colorable"
+	"github.com/fatih/color"
 	"github.com/vito/go-sse/sse"
 )
 
 func RenderStream(eventSource *sse.EventSource) (int, error) {
-	return Render(colorable.NewColorableStdout(), eventstream.NewSSEEventStream(eventSource)), nil
+	return Render(color.Output, eventstream.NewSSEEventStream(eventSource)), nil
 }

--- a/main.go
+++ b/main.go
@@ -10,8 +10,8 @@ import (
 	"github.com/concourse/fly/rc"
 	"github.com/concourse/fly/ui"
 	"github.com/concourse/go-concourse/concourse"
+	"github.com/fatih/color"
 	"github.com/jessevdk/go-flags"
-	colorable "github.com/mattn/go-colorable"
 
 	_ "github.com/concourse/atc/auth/genericoauth"
 	_ "github.com/concourse/atc/auth/github"
@@ -68,11 +68,11 @@ func main() {
 			fmt.Fprintln(ui.Stderr, "is the targeted Concourse running? better go catch it lol")
 		} else if err == commands.ErrShowHelpMessage {
 			helpParser.ParseArgs([]string{"-h"})
-			helpParser.WriteHelp(colorable.NewColorableStdout())
+			helpParser.WriteHelp(color.Output)
 			os.Exit(0)
 		} else if flagsErr, ok := err.(*flags.Error); ok && flagsErr.Type == flags.ErrCommandRequired {
 			helpParser.ParseArgs([]string{"-h"})
-			helpParser.WriteHelp(colorable.NewColorableStdout())
+			helpParser.WriteHelp(color.Output)
 			os.Exit(0)
 		} else {
 			fmt.Fprintf(ui.Stderr, "error: %s\n", err)

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/concourse/fly/ui"
 	"github.com/concourse/go-concourse/concourse"
 	"github.com/jessevdk/go-flags"
+	colorable "github.com/mattn/go-colorable"
 
 	_ "github.com/concourse/atc/auth/genericoauth"
 	_ "github.com/concourse/atc/auth/github"
@@ -67,11 +68,11 @@ func main() {
 			fmt.Fprintln(ui.Stderr, "is the targeted Concourse running? better go catch it lol")
 		} else if err == commands.ErrShowHelpMessage {
 			helpParser.ParseArgs([]string{"-h"})
-			helpParser.WriteHelp(os.Stdout)
+			helpParser.WriteHelp(colorable.NewColorableStdout())
 			os.Exit(0)
 		} else if flagsErr, ok := err.(*flags.Error); ok && flagsErr.Type == flags.ErrCommandRequired {
 			helpParser.ParseArgs([]string{"-h"})
-			helpParser.WriteHelp(os.Stdout)
+			helpParser.WriteHelp(colorable.NewColorableStdout())
 			os.Exit(0)
 		} else {
 			fmt.Fprintf(ui.Stderr, "error: %s\n", err)

--- a/pty/open_raw_term_windows.go
+++ b/pty/open_raw_term_windows.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"os"
 
-	colorable "github.com/mattn/go-colorable"
+	"github.com/fatih/color"
 )
 
 func IsTerminal() bool {
@@ -16,7 +16,7 @@ func IsTerminal() bool {
 func OpenRawTerm() (Term, error) {
 	return noopRestoreTerm{
 		Reader: os.Stdin,
-		Writer: colorable.NewColorableStdout(),
+		Writer: color.Output,
 	}, nil
 }
 

--- a/pty/open_raw_term_windows.go
+++ b/pty/open_raw_term_windows.go
@@ -5,6 +5,8 @@ package pty
 import (
 	"io"
 	"os"
+
+	colorable "github.com/mattn/go-colorable"
 )
 
 func IsTerminal() bool {
@@ -14,7 +16,7 @@ func IsTerminal() bool {
 func OpenRawTerm() (Term, error) {
 	return noopRestoreTerm{
 		Reader: os.Stdin,
-		Writer: os.Stdout,
+		Writer: colorable.NewColorableStdout(),
 	}, nil
 }
 


### PR DESCRIPTION
See issue: https://github.com/concourse/concourse/issues/1090

It looks like the fly cli uses os.Stdout for all of its write operations instead of using colorable.NewColorableStdout(). 

The windows terminal needs to have Ansi Escape Sequences enabled and the go-colorable package does this with the colorable.NewColorableStdout() function or the color.Output field.