### PR TITLE
fly jobs -p <pipeline> shows current build status

### DIFF
--- a/commands/jobs.go
+++ b/commands/jobs.go
@@ -30,7 +30,7 @@ func (command *JobsCommand) Execute([]string) error {
 	var jobs []atc.Job
 
 	jobs, err = target.Team().ListJobs(pipelineName)
-	headers = []string{"name", "paused", "status", "current"}
+	headers = []string{"name", "paused", "status", "next"}
 	if err != nil {
 		return err
 	}
@@ -78,17 +78,19 @@ func (command *JobsCommand) Execute([]string) error {
 		}
 		row = append(row, statusColumn)
 
-		var currentColumn ui.TableCell
+		var nextColumn ui.TableCell
 		if p.NextBuild != nil {
-			currentColumn.Contents = p.NextBuild.Status
+			nextColumn.Contents = p.NextBuild.Status
 			switch p.NextBuild.Status {
 			case "pending:":
-				currentColumn.Color = ui.PendingColor
+				nextColumn.Color = ui.PendingColor
 			case "started":
-				currentColumn.Color = ui.StartedColor
+				nextColumn.Color = ui.StartedColor
 			}
-			row = append(row, currentColumn)
+		} else {
+			nextColumn.Contents = "n/a"
 		}
+		row = append(row, nextColumn)
 
 		table.Data = append(table.Data, row)
 	}

--- a/commands/jobs.go
+++ b/commands/jobs.go
@@ -30,7 +30,7 @@ func (command *JobsCommand) Execute([]string) error {
 	var jobs []atc.Job
 
 	jobs, err = target.Team().ListJobs(pipelineName)
-	headers = []string{"name", "paused", "status"}
+	headers = []string{"name", "paused", "status", "current"}
 	if err != nil {
 		return err
 	}
@@ -77,6 +77,18 @@ func (command *JobsCommand) Execute([]string) error {
 			statusColumn.Contents = "n/a"
 		}
 		row = append(row, statusColumn)
+
+		var currentColumn ui.TableCell
+		if p.NextBuild != nil {
+			currentColumn.Contents = p.NextBuild.Status
+			switch p.NextBuild.Status {
+			case "pending:":
+				currentColumn.Color = ui.PendingColor
+			case "started":
+				currentColumn.Color = ui.StartedColor
+			}
+			row = append(row, currentColumn)
+		}
 
 		table.Data = append(table.Data, row)
 	}


### PR DESCRIPTION
This is a PR to fix [concourse issue #1768](https://github.com/concourse/concourse/issues/1768). An extra column showing current build status (started or pending) is added to the `fly jobs -p <pipeline>` output. On one of our pipelines it looks like this:

```
$ ./fly -t wings jobs -p bosh-bootloader
name                         paused  status     current
test-bosh-bootloader         no      succeeded
test-with-latest-terraform   no      succeeded
test-with-latest-bosh-cli    no      succeeded
bbl-downstream-docker-image  no      succeeded
major                        no      succeeded
minor                        no      succeeded
github-release               no      succeeded
aws-acceptance-tests         no      succeeded  started
gcp-acceptance-tests         no      failed     started
bump-nat-amis                no      succeeded
bump-brew-tap                no      succeeded
bbl-aws-cf                   no      succeeded
bbl-gcp-cf                   no      succeeded
releasable                   no      succeeded
passed-acceptance-tests      no      succeeded
bbl-gcp-concourse            no      succeeded
azure-acceptance-tests       no      succeeded  started
bbl-gcp-cf-with-cats         yes     failed     pending
bbl-aws-concourse            no      succeeded
bbl-lite-gcp                 no      succeeded
```