### PR TITLE
add new constructor to build an rc.Target with a token

### DIFF
--- a/rc/target.go
+++ b/rc/target.go
@@ -212,6 +212,42 @@ func NewBasicAuthTarget(
 	), nil
 }
 
+func NewOAuthTarget(
+	name TargetName,
+	url string,
+	teamName string,
+	insecure bool,
+	username string,
+	password string,
+	caCert string,
+	tracing bool,
+	atcToken *atc.AuthToken,
+) (Target, error) {
+	token := &TargetToken{
+		Type:  atcToken.Type,
+		Value: atcToken.Value,
+	}
+
+	caCertPool, err := loadCACertPool(caCert)
+	if err != nil {
+		return nil, err
+	}
+
+	httpClient := defaultHttpClient(token, insecure, caCertPool)
+	client := concourse.NewClient(url, httpClient, tracing)
+
+	return newTarget(
+		name,
+		teamName,
+		url,
+		token,
+		caCert,
+		caCertPool,
+		insecure,
+		client,
+	), nil
+}
+
 func NewNoAuthTarget(
 	name TargetName,
 	url string,


### PR DESCRIPTION
This makes it easier to use fly as a library as it let's you instantiate an authenticated target without having to save and load to the .flyrc file eg:

```golang
loginTarget, err := rc.NewBasicAuthTarget(
  "default",
  config.URL,
  config.TeamName,
  config.Insecure,
  config.Username,
  config.Password,
  config.CACert,
  config.Trace,
)
if err != nil {
  return err
}

token, err := loginTarget.Team().AuthToken()
if err != nil {
  return err
}

target, err := rc.NewOAuthTarget(
  "default",
  config.URL,
  config.TeamName,
  config.Insecure,
  config.Username,
  config.Password,
  config.CACert,
  config.Trace,
  &token,
)
if err != nil {
  return err
}
```

I didn't add any tests as this is mostly glue code and there weren't any existing tests for the rc.Target constructors, however I have verified that the code works as intended and am using it in a project that uses `github.com/concourse/fly/rc` as a library