### PR TITLE
Try login and retry given command on authentication errors.

### DIFF
--- a/integration/error_handling_test.go
+++ b/integration/error_handling_test.go
@@ -3,6 +3,8 @@ package integration_test
 import (
 	"os/exec"
 
+	"github.com/concourse/atc"
+	"github.com/concourse/skymarshal/provider"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
@@ -30,15 +32,28 @@ var _ = Describe("Fly CLI", func() {
 				)
 			})
 
-			It("instructs the user to log in", func() {
-				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
-				Expect(err).ToNot(HaveOccurred())
+			Context("with non-terminal stdin", func() {
+				It("prints the error", func() {
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).ToNot(HaveOccurred())
 
-				<-sess.Exited
-				Expect(sess.ExitCode()).To(Equal(1))
+					<-sess.Exited
+					Expect(sess.ExitCode()).To(Equal(1))
+					Expect(sess.Err).To(gbytes.Say("not authorized\\. run the following to log in:\n\n    "))
+					Expect(sess.Err).To(gbytes.Say(`fly -t ` + targetName + ` login`))
+				})
+			})
 
-				Expect(sess.Err).To(gbytes.Say("not authorized\\. run the following to log in:\n\n    "))
-				Expect(sess.Err).To(gbytes.Say(`fly -t ` + targetName + ` login`))
+			Context("with non-terminal stdout", func() {
+				It("prints the error", func() {
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).ToNot(HaveOccurred())
+
+					<-sess.Exited
+					Expect(sess.ExitCode()).To(Equal(1))
+					Expect(sess.Err).To(gbytes.Say("not authorized\\. run the following to log in:\n\n    "))
+					Expect(sess.Err).To(gbytes.Say(`fly -t ` + targetName + ` login`))
+				})
 			})
 		})
 	})


### PR DESCRIPTION
To make fly a bit quicker than `enter command`, `re-login`, `arrow up`.

Closes https://github.com/concourse/concourse/issues/1099.

Example:
```
./fly -t ci workers
could not find a valid token.
logging in to team 'main'

navigate to the following URL in your browser:

    https://concourse.example.com/auth/github?team_name=main&fly_local_port=64548

or enter token manually: 
target saved
name                         containers  platform  tags  team  state    version
worker-concourse-1  91       linux     none  none  running  none   

```