### PR TITLE
Use `yaml.UnmarshalStrict()` during strict validation

### DIFF
--- a/commands/internal/setpipelinehelpers/atc_config.go
+++ b/commands/internal/setpipelinehelpers/atc_config.go
@@ -48,11 +48,22 @@ func (atcConfig ATCConfig) Validate(
 	templateVariablesFiles []atc.PathFlag,
 	strict bool,
 ) error {
-	newConfig := atcConfig.newConfig(configPath, templateVariablesFiles, templateVariables, yamlTemplateVariables, true)
+	newConfig, err := atcConfig.newConfig(configPath, templateVariablesFiles, templateVariables, yamlTemplateVariables, true, strict)
+	if err != nil {
+		return err
+	}
 
 	var new atc.Config
-	if err := yaml.Unmarshal([]byte(newConfig), &new); err != nil {
-		return err
+	if strict {
+		// UnmarshalStrict will pick up fields in structs that have the wrong names, as well as any duplicate keys in maps
+		// we should consider always using this everywhere in a later release...
+		if err := yaml.UnmarshalStrict([]byte(newConfig), &new); err != nil {
+			return err
+		}
+	} else {
+		if err := yaml.Unmarshal([]byte(newConfig), &new); err != nil {
+			return err
+		}
 	}
 
 	warnings, errorMessages := new.Validate()
@@ -79,7 +90,10 @@ func (atcConfig ATCConfig) Validate(
 }
 
 func (atcConfig ATCConfig) Set(configPath atc.PathFlag, templateVariables []flaghelpers.VariablePairFlag, yamlTemplateVariables []flaghelpers.YAMLVariablePairFlag, templateVariablesFiles []atc.PathFlag) error {
-	newConfig := atcConfig.newConfig(configPath, templateVariablesFiles, templateVariables, yamlTemplateVariables, false)
+	newConfig, err := atcConfig.newConfig(configPath, templateVariablesFiles, templateVariables, yamlTemplateVariables, false, false)
+	if err != nil {
+		return err
+	}
 	existingConfig, _, existingConfigVersion, _, err := atcConfig.Team.PipelineConfig(atcConfig.PipelineName)
 	errorMessages := []string{}
 	if err != nil {
@@ -130,17 +144,30 @@ func (atcConfig ATCConfig) newConfig(
 	templateVariables []flaghelpers.VariablePairFlag,
 	yamlTemplateVariables []flaghelpers.YAMLVariablePairFlag,
 	allowEmpty bool,
-) []byte {
+	strict bool,
+) ([]byte, error) {
 	evaluatedConfig, err := ioutil.ReadFile(string(configPath))
 	if err != nil {
-		displayhelpers.FailWithErrorf("could not read config file", err)
+		return nil, fmt.Errorf("could not read config file: %s", err.Error())
+	}
+
+	if strict {
+		// We use a generic map here, since templates are not evaluated yet.
+		// (else a template string may cause an error when a struct is expected)
+		// If we don't check Strict now, then the subsequent steps will mask any
+		// duplicate key errors.
+		// We should consider being strict throughout the entire stack by default.
+		err = yaml.UnmarshalStrict(evaluatedConfig, make(map[string]interface{}))
+		if err != nil {
+			return nil, fmt.Errorf("error parsing yaml before applying templates: %s", err.Error())
+		}
 	}
 
 	var paramPayloads [][]byte
 	for _, path := range templateVariablesFiles {
 		templateVars, err := ioutil.ReadFile(string(path))
 		if err != nil {
-			displayhelpers.FailWithErrorf("could not read template variables file (%s)", err, string(path))
+			return nil, fmt.Errorf("could not read template variables file (%s): %s", string(path), err.Error())
 		}
 
 		paramPayloads = append(paramPayloads, templateVars)
@@ -149,16 +176,16 @@ func (atcConfig ATCConfig) newConfig(
 	if temp.Present(evaluatedConfig) {
 		evaluatedConfig, err = atcConfig.resolveDeprecatedTemplateStyle(evaluatedConfig, paramPayloads, templateVariables, yamlTemplateVariables, allowEmpty)
 		if err != nil {
-			displayhelpers.FailWithErrorf("could not resolve old-style template vars", err)
+			return nil, fmt.Errorf("could not resolve old-style template vars: %s", err.Error())
 		}
 	}
 
 	evaluatedConfig, err = atcConfig.resolveTemplates(evaluatedConfig, paramPayloads, templateVariables, yamlTemplateVariables)
 	if err != nil {
-		displayhelpers.FailWithErrorf("could not resolve template vars", err)
+		return nil, fmt.Errorf("could not resolve template vars: %s", err.Error())
 	}
 
-	return evaluatedConfig
+	return evaluatedConfig, nil
 }
 
 func (atcConfig ATCConfig) resolveTemplates(configPayload []byte, paramPayloads [][]byte, variables []flaghelpers.VariablePairFlag, yamlVariables []flaghelpers.YAMLVariablePairFlag) ([]byte, error) {

--- a/commands/internal/setpipelinehelpers/atc_config_test.go
+++ b/commands/internal/setpipelinehelpers/atc_config_test.go
@@ -1,6 +1,11 @@
 package setpipelinehelpers_test
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/concourse/atc"
 	. "github.com/concourse/fly/commands/internal/setpipelinehelpers"
 
 	. "github.com/onsi/ginkgo"
@@ -20,6 +25,104 @@ var _ = Describe("ATC Config", func() {
 			It("returns true", func() {
 				Expect(atcConfig.ApplyConfigInteraction()).To(BeTrue())
 			})
+		})
+	})
+
+	Describe("validating", func() {
+		var atcConfig ATCConfig
+		var tmpdir string
+
+		BeforeEach(func() {
+			atcConfig = ATCConfig{}
+
+			var err error
+
+			tmpdir, err = ioutil.TempDir("", "fly-test")
+			Expect(err).NotTo(HaveOccurred())
+
+			err = ioutil.WriteFile(
+				filepath.Join(tmpdir, "good-pipeline.yml"),
+				[]byte(`---
+resource_types:
+- name: foo
+  type: docker-image
+  source:
+    repository: foo/foo
+- name: bar
+  type: docker-image
+  source:
+    repository: bar/bar
+jobs:
+- name: hello-world
+  plan:
+  - task: say-hello
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source: {repository: ubuntu}
+      run:
+        path: echo
+        args: ["Hello, world!"]
+`),
+				0644,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = ioutil.WriteFile(
+				filepath.Join(tmpdir, "dupkey-pipeline.yml"),
+				[]byte(`---
+resource_types:
+- name: foo
+  type: docker-image
+  source:
+    repository: foo/foo
+- name: bar
+  type: docker-image
+  source:
+    repository: bar/bar
+jobs:
+- name: hello-world
+  plan:
+  - task: say-hello
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source: {repository: ubuntu}
+      run:
+        path: echo
+        args: ["Hello, world!"]
+resource_types:
+- name: baz
+  type: docker-image
+  source:
+    repository: baz/baz
+`),
+				0644,
+			)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			os.RemoveAll(tmpdir)
+		})
+
+		It("validates a good pipeline", func() {
+			err := atcConfig.Validate(atc.PathFlag(filepath.Join(tmpdir, "good-pipeline.yml")), nil, nil, nil, false)
+			Expect(err).To(BeNil())
+		})
+		It("validates a good pipeline with strict", func() {
+			err := atcConfig.Validate(atc.PathFlag(filepath.Join(tmpdir, "good-pipeline.yml")), nil, nil, nil, true)
+			Expect(err).To(BeNil())
+		})
+		It("do not fail validating a pipeline with repeated resource types (probably should but for compat doesn't)", func() {
+			err := atcConfig.Validate(atc.PathFlag(filepath.Join(tmpdir, "dupkey-pipeline.yml")), nil, nil, nil, false)
+			Expect(err).To(BeNil())
+		})
+		It("fail validating a pipeline with repeated resource types with strict", func() {
+			err := atcConfig.Validate(atc.PathFlag(filepath.Join(tmpdir, "dupkey-pipeline.yml")), nil, nil, nil, true)
+			Expect(err).ToNot(BeNil())
 		})
 	})
 })


### PR DESCRIPTION
Earlier this week the https://github.com/go-yaml/yaml/pull/307 landed which adds checking of duplicate keys when unmarshaling yaml, which would have saved me a few hours with a buggy pipeline that [I wrote](https://github.com/go-yaml/yaml/issues/284).

This PR changes to the behaviour of `verify-pipeline` to use `yaml.UnmarshalStrict()`, only when the existing `--strict` option is set. This also has the benefit of picking up any field names in a yaml file that don't match a struct (when unmarshalled into a map, anything is allowed) which can help detect typos.

Note that in order for these tests to pass, you will need to vendor in a new version of `gopkg.in/yaml.v2`. I'm not sure how they plan to update their branch - in my testing of below I updated to the tip of the `devel` branch at https://github.com/go-yaml/yaml, which I verified passes the full set of integration tests (`testflight`).

```diff
diff --git a/src/gopkg.in/yaml.v2 b/src/gopkg.in/yaml.v2
index e4d366fc..031c9222 160000
--- a/src/gopkg.in/yaml.v2
+++ b/src/gopkg.in/yaml.v2
@@ -1 +1 @@
-Subproject commit e4d366fc3c7938e2958e662b4258c7a89e1f0e3e
+Subproject commit 031c922227a592b2b562a1833438308381f9a8bf
```

(maybe you'll want to wait for a newer release from them?)

Anyway, submitting the PR now with some basic tests.

It might be interesting to consider using `yaml.UnmarshalStrict()` everywhere that `yaml.Unmarshal()` is used, but that's a bigger change to contemplate.