### PR TITLE
Fix domain.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A command line interface that runs a build in a container with [ATC](https://github.com/concourse/atc).
 
-[The documentation](http://concourse.ci/fly-cli.html) is hosted together with Concourse's docs.
+[The documentation](https://concourse-ci.org/fly-cli.html) is hosted together with Concourse's docs.
 
-A good place to start learning about Concourse is [its documentation](http://concourse.ci/introduction.html)
+A good place to start learning about Concourse is [its documentation](https://concourse-ci.org/introduction.html)
 or its [BOSH release](https://github.com/concourse/concourse).
 
 ## Reporting Issues and Requesting Features


### PR DESCRIPTION
This fix corrects the domain in the README.md from concourse.ci to concourse-ci.org.