### PR TITLE
Fix dead link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A command line interface that runs a build in a container with [ATC](https://git
 
 [The documentation](https://concourse-ci.org/fly.html) is hosted together with Concourse's docs.
 
-A good place to start learning about Concourse is [its documentation](http://concourse-ci.org/introduction.html)
+A good place to start learning about Concourse is [its documentation](https://concourse-ci.org/docs.html)
 or its [BOSH release](https://github.com/concourse/concourse).
 
 ## Reporting Issues and Requesting Features


### PR DESCRIPTION
`http://concourse-ci.org/introduction.html` respond with 404