### PR TITLE
allow custom resource type to be resolved when fly execute -j

### DIFF
--- a/commands/internal/executehelpers/inputs.go
+++ b/commands/internal/executehelpers/inputs.go
@@ -145,6 +145,15 @@ func FetchInputsFromJob(fact atc.PlanFactory, team concourse.Team, inputsFrom fl
 		return nil, errors.New("build inputs not found")
 	}
 
+	versionedResourceTypes, found, err := team.VersionedResourceTypes(inputsFrom.PipelineName)
+	if err != nil {
+		return nil, err
+	}
+
+	if !found {
+		return nil, errors.New("versioned resource types not found")
+	}
+
 	for _, buildInput := range buildInputs {
 		version := buildInput.Version
 
@@ -158,6 +167,7 @@ func FetchInputsFromJob(fact atc.PlanFactory, team concourse.Team, inputsFrom fl
 				Version: &version,
 				Params:  buildInput.Params,
 				Tags:    buildInput.Tags,
+				VersionedResourceTypes: versionedResourceTypes,
 			}),
 		}
 	}


### PR DESCRIPTION
This PR depends on 
https://github.com/concourse/go-concourse/pull/11

i.e. the PR 11 in `go-concourse` has to be merged first.