### PR TITLE
Clarify what --include-ignored actually does

### DIFF
--- a/commands/execute.go
+++ b/commands/execute.go
@@ -22,7 +22,7 @@ import (
 type ExecuteCommand struct {
 	TaskConfig     atc.PathFlag                 `short:"c" long:"config" required:"true"                description:"The task config to execute"`
 	Privileged     bool                         `short:"p" long:"privileged"                            description:"Run the task with full privileges"`
-	IncludeIgnored bool                         `          long:"include-ignored"                       description:"Including .gitignored paths. Disregards .gitignore entries and uploads everything"`
+	IncludeIgnored bool                         `          long:"include-ignored"                       description:"Including .gitignored paths and hidden files. Disregards .gitignore entries and uploads everything"`
 	Inputs         []flaghelpers.InputPairFlag  `short:"i" long:"input"       value-name:"NAME=PATH"    description:"An input to provide to the task (can be specified multiple times)"`
 	InputsFrom     flaghelpers.JobFlag          `short:"j" long:"inputs-from" value-name:"PIPELINE/JOB" description:"A job to base the inputs on"`
 	Outputs        []flaghelpers.OutputPairFlag `short:"o" long:"output"      value-name:"NAME=PATH"    description:"An output to fetch from the task (can be specified multiple times)"`


### PR DESCRIPTION
Hidden files are not uploaded without this flag. I needed `.git` to be uploaded since this was a git-resource input.

It seems like a valid use case to want your `.git` dir to be uploaded since `.git` is in the input when the git resource gets it. It would be nice to be able to include it and not the files in `.gitignore`. Perhaps there should be two flags, `--include-hidden` and `--include-ignored`? I'm happy with just clarifying the help text.