### PR TITLE
Remove New-line in open-url

### DIFF
--- a/commands/login.go
+++ b/commands/login.go
@@ -149,7 +149,7 @@ func (command *LoginCommand) authCodeGrant(targetUrl string) (string, string, er
 
 	fmt.Println("navigate to the following URL in your browser:")
 	fmt.Println("")
-	fmt.Printf("  %s", openURL)
+	fmt.Printf("  %s\n", openURL)
 	fmt.Println("")
 
 	if command.OpenBrowser {

--- a/commands/login.go
+++ b/commands/login.go
@@ -145,7 +145,7 @@ func (command *LoginCommand) authCodeGrant(targetUrl string) (string, string, er
 		panic(err)
 	}
 
-	openURL := fmt.Sprintf("%s/sky/login?redirect_uri=%s\n", targetUrl, redirectUri.String())
+	openURL := fmt.Sprintf("%s/sky/login?redirect_uri=%s", targetUrl, redirectUri.String())
 
 	fmt.Println("navigate to the following URL in your browser:")
 	fmt.Println("")


### PR DESCRIPTION
At least of macOs with chrome, the newline will end up in the browser as %0A, which results in a 500 error in ATC.
E.g.
https://<concourse-url>/auth/github?team_name=main&fly_local_port=56243%0A