### PR TITLE
forcing fly under darwin to load system root ca by x509 method

### DIFF
--- a/commands/internal/setpipelinehelpers/atc_config.go
+++ b/commands/internal/setpipelinehelpers/atc_config.go
@@ -83,8 +83,6 @@ func (atcConfig ATCConfig) Validate(
 		displayhelpers.Failf("configuration invalid")
 	}
 
-	fmt.Println("looks good")
-
 	return nil
 }
 

--- a/rc/target.go
+++ b/rc/target.go
@@ -386,7 +386,7 @@ func defaultHttpClient(token *TargetToken, insecure bool, caCertPool *x509.CertP
 }
 
 func loadCACertPool(caCert string) (cert *x509.CertPool, err error) {
-	if caCert == "" {
+	if caCert == "" && runtime.GOOS != "darwin" {
 		return nil, nil
 	}
 
@@ -404,10 +404,13 @@ func loadCACertPool(caCert string) (cert *x509.CertPool, err error) {
 		pool = x509.NewCertPool()
 	}
 
-	ok := pool.AppendCertsFromPEM([]byte(caCert))
-	if !ok {
-		return nil, errors.New("CA Cert not valid")
+	if caCert != "" {
+		ok := pool.AppendCertsFromPEM([]byte(caCert))
+		if !ok {
+			return nil, errors.New("CA Cert not valid")
+		}
 	}
+
 	return pool, nil
 }
 

--- a/rc/target_test.go
+++ b/rc/target_test.go
@@ -100,9 +100,18 @@ AA9WjQKZ7aKQRUzkuxCkPfAyAw7xzvjoyVGM5mKf5p/AfbdynMk2OmufTqj/ZA1k
 				})))
 				base, ok := (*transport).Base.(*http.Transport)
 				Expect(ok).To(BeTrue())
+
+				var expectedCaCertPool *x509.CertPool
+				if runtime.GOOS != "windows" {
+					expectedCaCertPool, err = x509.SystemCertPool()
+					Expect(err).NotTo(HaveOccurred())
+				} else {
+					expectedCaCertPool = x509.NewCertPool()
+				}
+
 				Expect((*base).TLSClientConfig).To(Equal(&tls.Config{
 					InsecureSkipVerify: true,
-					RootCAs:            nil,
+					RootCAs:            expectedCaCertPool,
 				}))
 			})
 		})


### PR DESCRIPTION
Trying to fix https://github.com/concourse/concourse/issues/2133

Whey @bsnchan had the issue I got a chance to check their environment. It seems like the issue is scoped to darwin where `keychain` manages system root CA and intermediate CA differently. If there is no ca_cert specified, fly tends to let tls to populate the [RootCA](https://golang.org/pkg/crypto/tls/#Config) itself, which ends up picking up the CA sets under system root only (not 100% sure if it is using the same way that x509 does. If it is then it would be a bug that golang could not fully load system CAs under darwin). 

`x509.SystemCertPool()` instead will pick up from both places refer to [here](https://golang.org/src/crypto/x509/root_darwin.go)

A related read [here](https://github.com/golang/go/issues/16532#issuecomment-279121337) mentions for adding intermediate CA to system root CA in darwin is prohibited thus fly in this case needs to load that from `~/Library/Keychains/login.keychain` or `/Library/Keychains/System.keychain`