### PR TITLE
[#35] Update to `teams` to account for --allow-all-users

### DIFF
--- a/commands/teams.go
+++ b/commands/teams.go
@@ -61,20 +61,27 @@ func (command *TeamsCommand) Execute([]string) error {
 		if command.Details {
 			var usersCell, groupsCell ui.TableCell
 
-			if len(t.Auth["users"]) == 0 {
+			hasUsers := len(t.Auth["users"]) != 0
+			hasGroups := len(t.Auth["groups"]) != 0
+
+			if !hasUsers && !hasGroups{
+				usersCell.Contents = "all"
+				usersCell.Color = color.New(color.Faint)
+			} else if !hasUsers {
 				usersCell.Contents = "none"
 				usersCell.Color = color.New(color.Faint)
-			}else {
+			} else {
 				usersCell.Contents = strings.Join(t.Auth["users"],",")
 			}
-			row = append(row, usersCell)
 
-			if len(t.Auth["groups"]) == 0 {
+			if hasGroups {
+				groupsCell.Contents = strings.Join(t.Auth["groups"],",")
+			} else {
 				groupsCell.Contents = "none"
 				groupsCell.Color = color.New(color.Faint)
-			}else {
-				groupsCell.Contents = strings.Join(t.Auth["groups"],",")
 			}
+
+			row = append(row, usersCell)
 			row = append(row, groupsCell)
 		}
 

--- a/integration/teams_test.go
+++ b/integration/teams_test.go
@@ -147,7 +147,7 @@ var _ = Describe("Fly CLI", func() {
 							{{Contents: "a-team"}, {Contents: "none"}, {Contents: "github:github-org"}},
 							{{Contents: "b-team"}, {Contents: "github:github-user"}, {Contents: "none"}},
 							{{Contents: "c-team"}, {Contents: "github:github-user"}, {Contents: "github:github-org"}},
-							{{Contents: "main"}, {Contents: "none"}, {Contents: "none"}},
+							{{Contents: "main"}, {Contents: "all"}, {Contents: "none"}},
 						},
 					}))
 				})


### PR DESCRIPTION
* when flag "--allow-all-usrs" is passed in, `users` shows "all"

Signed-off-by: Saman Alvi <salvi@pivotal.io>