### PR TITLE
Add `fly resources` command

### DIFF
--- a/commands/fly.go
+++ b/commands/fly.go
@@ -51,6 +51,7 @@ type FlyCommand struct {
 	CheckResource    CheckResourceCommand    `command:"check-resource"    alias:"cr" description:"Check a resource"`
 	PauseResource    PauseResourceCommand    `command:"pause-resource"    alias:"pr" description:"Pause a resource"`
 	UnpauseResource  UnpauseResourceCommand  `command:"unpause-resource"  alias:"ur" description:"Unpause a resource"`
+	Resources        ResourcesCommand        `command:"resources" alias:"rs" description:"Print the active resources"`
 
 	Builds     BuildsCommand     `command:"builds"      alias:"bs" description:"List builds data"`
 	AbortBuild AbortBuildCommand `command:"abort-build" alias:"ab" description:"Abort a build"`

--- a/commands/resources.go
+++ b/commands/resources.go
@@ -1,0 +1,97 @@
+package commands
+
+import (
+	"os"
+	"sort"
+	"strconv"
+
+	"github.com/concourse/fly/commands/internal/displayhelpers"
+	"github.com/concourse/fly/rc"
+	"github.com/concourse/fly/ui"
+	"github.com/fatih/color"
+)
+
+type ResourcesCommand struct {
+	Json     bool `long:"json"  description:"Print command result as JSON"`
+	Detailed bool `short:"d"  long:"detailed"  description:"Get detailed information such as resource name and pipeline name"`
+}
+
+func (command *ResourcesCommand) Execute([]string) error {
+	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	if err != nil {
+		return err
+	}
+
+	err = target.Validate()
+	if err != nil {
+		return err
+	}
+
+	detailed := command.Detailed
+
+	containers, err := target.Team().ListCheckContainerDetails(detailed)
+	if err != nil {
+		return err
+	}
+
+	if command.Json {
+		err = displayhelpers.JsonPrint(containers)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	table := ui.Table{
+		Headers: ui.TableRow{
+			{Contents: "handle", Color: color.New(color.Bold)},
+			{Contents: "worker", Color: color.New(color.Bold)},
+			{Contents: "container-type", Color: color.New(color.Bold)},
+			{Contents: "resource-config-id", Color: color.New(color.Bold)},
+			{Contents: "resource-type", Color: color.New(color.Bold)},
+		},
+	}
+
+	if detailed {
+		table.Headers = append(table.Headers,
+			ui.TableCell{Contents: "pipeline", Color: color.New(color.Bold)},
+			ui.TableCell{Contents: "resource-name", Color: color.New(color.Bold)},
+		)
+	}
+
+	for _, c := range containers {
+		row := ui.TableRow{
+			{Contents: c.ID},
+			{Contents: c.WorkerName},
+			{Contents: c.Type},
+			intOrDefault(c.ResourceConfigID),
+			stringOrDefault(c.ResourceTypeName),
+		}
+
+		if detailed {
+			row = append(row,
+				stringOrDefault(c.PipelineName),
+				stringOrDefault(c.ResourceName),
+			)
+		}
+
+		table.Data = append(table.Data, row)
+	}
+
+	sort.Sort(table.Data)
+
+	return table.Render(os.Stdout, Fly.PrintTableHeaders)
+}
+
+func intOrDefault(id int) ui.TableCell {
+	var column ui.TableCell
+
+	if id == 0 {
+		column.Contents = "none"
+		column.Color = color.New(color.Faint)
+	} else {
+		column.Contents = strconv.Itoa(id)
+	}
+
+	return column
+}

--- a/integration/containers_test.go
+++ b/integration/containers_test.go
@@ -165,4 +165,270 @@ var _ = Describe("Fly CLI", func() {
 			})
 		})
 	})
+
+	Describe("resources", func() {
+		var (
+			flyCmd *exec.Cmd
+		)
+
+		BeforeEach(func() {
+			flyCmd = exec.Command(flyPath, "-t", targetName, "resources")
+		})
+
+		Context("when check containers summary is returned from the API", func() {
+			BeforeEach(func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/api/v1/teams/main/checkcontainers"),
+						ghttp.RespondWithJSONEncoded(200, []atc.Container{
+							{
+								ID:               "handle-1",
+								WorkerName:       "worker-name-1",
+								Type:             "check",
+								ResourceConfigID: 432,
+								ResourceTypeName: "git",
+							},
+							{
+								ID:               "handle-2",
+								WorkerName:       "worker-name-1",
+								Type:             "check",
+								ResourceConfigID: 433,
+								ResourceTypeName: "bitbucket-build-status",
+							},
+							{
+								ID:               "handle-3",
+								WorkerName:       "worker-name-2",
+								Type:             "check",
+								ResourceConfigID: 434,
+								ResourceTypeName: "Used by parent resource 433",
+							},
+						}),
+					),
+				)
+			})
+
+			Context("when --json is given", func() {
+				BeforeEach(func() {
+					flyCmd.Args = append(flyCmd.Args, "--json")
+				})
+
+				It("prints response in json as stdout", func() {
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(sess).Should(gexec.Exit(0))
+					Expect(sess.Out.Contents()).To(MatchJSON(`[
+	      {
+		"id":               "handle-1",
+		"worker_name":       "worker-name-1",
+		"type":             "check",
+		"resource_config_id": 432,
+		"resource_type_name":     "git"
+	      },
+	      {
+		"id":               "handle-2",
+		"worker_name":       "worker-name-1",
+		"type":             "check",
+		"resource_config_id": 433,
+		"resource_type_name":     "bitbucket-build-status"
+	      },
+	      {
+	 	"id":               "handle-3",
+	 	"worker_name":       "worker-name-2",
+	 	"type":             "check",
+	 	"resource_config_id": 434,
+	 	"resource_type_name":     "Used by parent resource 433"
+	      }
+            ]`))
+				})
+			})
+
+			It("lists them to the user, ordered by name", func() {
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(sess).Should(gexec.Exit(0))
+				Expect(sess.Out).To(PrintTable(ui.Table{
+					Headers: ui.TableRow{
+						{Contents: "handle", Color: color.New(color.Bold)},
+						{Contents: "worker", Color: color.New(color.Bold)},
+						{Contents: "container-type", Color: color.New(color.Bold)},
+						{Contents: "resource-config-id", Color: color.New(color.Bold)},
+						{Contents: "resource-type", Color: color.New(color.Bold)},
+					},
+					Data: []ui.TableRow{
+						{{Contents: "handle-1"}, {Contents: "worker-name-1"}, {Contents: "check"}, {Contents: "432"}, {Contents: "git"}},
+						{{Contents: "handle-2"}, {Contents: "worker-name-1"}, {Contents: "check"}, {Contents: "433"}, {Contents: "bitbucket-build-status"}},
+						{{Contents: "handle-3"}, {Contents: "worker-name-2"}, {Contents: "check"}, {Contents: "434"}, {Contents: "Used by parent resource 433"}},
+					},
+				}))
+			})
+		})
+
+		Context("when check containers details are returned from the API", func() {
+			BeforeEach(func() {
+				flyCmd.Args = append(flyCmd.Args, "--detailed")
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/api/v1/teams/main/checkcontainersdetailed"),
+						ghttp.RespondWithJSONEncoded(200, []atc.Container{
+							{
+								ID:               "handle-1",
+								WorkerName:       "worker-name-1",
+								Type:             "check",
+								PipelineID:       1,
+								PipelineName:     "mypipeline-1",
+								ResourceConfigID: 432,
+								ResourceName:     "myresourcename-1",
+								ResourceTypeName: "git",
+							},
+							{
+								ID:               "handle-1",
+								WorkerName:       "worker-name-1",
+								Type:             "check",
+								PipelineID:       2,
+								PipelineName:     "mypipeline-2",
+								ResourceConfigID: 432,
+								ResourceName:     "myresourcename-2",
+								ResourceTypeName: "git",
+							},
+							{
+								ID:               "handle-1",
+								WorkerName:       "worker-name-1",
+								Type:             "check",
+								PipelineID:       1,
+								PipelineName:     "mypipeline-1",
+								ResourceConfigID: 432,
+								ResourceName:     "myresourcename-2",
+								ResourceTypeName: "git",
+							},
+							{
+								ID:               "handle-2",
+								WorkerName:       "worker-name-1",
+								Type:             "check",
+								ResourceConfigID: 433,
+								ResourceTypeName: "bitbucket-build-status",
+							},
+							{
+								ID:               "handle-3",
+								WorkerName:       "worker-name-2",
+								Type:             "check",
+								PipelineID:       1,
+								PipelineName:     "mypipeline-1",
+								ResourceConfigID: 434,
+								ResourceName:     "myresourcename-3",
+								ResourceTypeName: "Used by parent resource 433",
+							},
+						}),
+					),
+				)
+			})
+
+			Context("when --json is given", func() {
+				BeforeEach(func() {
+					flyCmd.Args = append(flyCmd.Args, "--json")
+				})
+
+				It("prints response in json as stdout", func() {
+					sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+					Expect(err).NotTo(HaveOccurred())
+
+					Eventually(sess).Should(gexec.Exit(0))
+					Expect(sess.Out.Contents()).To(MatchJSON(`[
+	      {
+		      "id":               "handle-1",
+		      "worker_name":       "worker-name-1",
+		      "type":             "check",
+		      "pipeline_id":       1,
+		      "pipeline_name":     "mypipeline-1",
+		      "resource_config_id": 432,
+		      "resource_name":     "myresourcename-1",
+		      "resource_type_name": "git"
+	      },
+	      {
+		      "id":               "handle-1",
+		      "worker_name":       "worker-name-1",
+		      "type":             "check",
+		      "pipeline_id":       2,
+		      "pipeline_name":     "mypipeline-2",
+		      "resource_config_id": 432,
+		      "resource_name":     "myresourcename-2",
+		      "resource_type_name": "git"
+	      },
+	      {
+		      "id":               "handle-1",
+		      "worker_name":       "worker-name-1",
+		      "type":             "check",
+		      "pipeline_id":       1,
+		      "pipeline_name":     "mypipeline-1",
+		      "resource_config_id": 432,
+		      "resource_name":     "myresourcename-2",
+		      "resource_type_name": "git"
+	      },
+	      {
+		      "id":               "handle-2",
+		      "worker_name":       "worker-name-1",
+		      "type":             "check",
+		      "resource_config_id": 433,
+		      "resource_type_name": "bitbucket-build-status"
+	      },
+	      {
+		      "id":               "handle-3",
+		      "worker_name":       "worker-name-2",
+		      "type":             "check",
+		      "pipeline_id":       1,
+		      "pipeline_name":     "mypipeline-1",
+		      "resource_config_id": 434,
+		      "resource_name":     "myresourcename-3",
+		      "resource_type_name": "Used by parent resource 433"
+	      }
+            ]`))
+				})
+			})
+
+			It("lists them to the user, ordered by name", func() {
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(sess).Should(gexec.Exit(0))
+				Expect(sess.Out).To(PrintTable(ui.Table{
+					Headers: ui.TableRow{
+						{Contents: "handle", Color: color.New(color.Bold)},
+						{Contents: "worker", Color: color.New(color.Bold)},
+						{Contents: "container-type", Color: color.New(color.Bold)},
+						{Contents: "resource-config-id", Color: color.New(color.Bold)},
+						{Contents: "resource-type", Color: color.New(color.Bold)},
+						{Contents: "pipeline", Color: color.New(color.Bold)},
+						{Contents: "resource-name", Color: color.New(color.Bold)},
+					},
+					Data: []ui.TableRow{
+						{{Contents: "handle-1"}, {Contents: "worker-name-1"}, {Contents: "check"}, {Contents: "432"}, {Contents: "git"}, {Contents: "mypipeline-1"}, {Contents: "myresourcename-1"}},
+						{{Contents: "handle-1"}, {Contents: "worker-name-1"}, {Contents: "check"}, {Contents: "432"}, {Contents: "git"}, {Contents: "mypipeline-2"}, {Contents: "myresourcename-2"}},
+						{{Contents: "handle-1"}, {Contents: "worker-name-1"}, {Contents: "check"}, {Contents: "432"}, {Contents: "git"}, {Contents: "mypipeline-1"}, {Contents: "myresourcename-2"}},
+						{{Contents: "handle-2"}, {Contents: "worker-name-1"}, {Contents: "check"}, {Contents: "433"}, {Contents: "bitbucket-build-status"}, {Contents: "none", Color: color.New(color.Faint)}, {Contents: "none", Color: color.New(color.Faint)}},
+						{{Contents: "handle-3"}, {Contents: "worker-name-2"}, {Contents: "check"}, {Contents: "434"}, {Contents: "Used by parent resource 433"}, {Contents: "mypipeline-1"}, {Contents: "myresourcename-3"}},
+					},
+				}))
+			})
+		})
+
+		Context("and the api returns an internal server error", func() {
+			BeforeEach(func() {
+				atcServer.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/api/v1/teams/main/checkcontainers"),
+						ghttp.RespondWith(500, ""),
+					),
+				)
+			})
+
+			It("writes an error message to stderr", func() {
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(sess).Should(gexec.Exit(1))
+				Eventually(sess.Err).Should(gbytes.Say("Unexpected Response"))
+			})
+		})
+	})
 })


### PR DESCRIPTION
This adds the `fly resources` command requested in concourse/concourse#1149.

This PR is intended to go along with 2 other PRs:
concourse/atc#295
concourse/go-concourse#14