### PR TITLE
Add --check-creds option to fly

### DIFF
--- a/commands/internal/setpipelinehelpers/atc_config.go
+++ b/commands/internal/setpipelinehelpers/atc_config.go
@@ -20,11 +20,11 @@ import (
 )
 
 type ATCConfig struct {
-	PipelineName    string
-	Team            concourse.Team
-	Target          string
-	SkipInteraction bool
-	SkipCredentials bool
+	PipelineName     string
+	Team             concourse.Team
+	Target           string
+	SkipInteraction  bool
+	CheckCredentials bool
 }
 
 func (atcConfig ATCConfig) ApplyConfigInteraction() bool {
@@ -130,7 +130,7 @@ func (atcConfig ATCConfig) Set(configPath atc.PathFlag, templateVariables []flag
 		atcConfig.PipelineName,
 		existingConfigVersion,
 		newConfig,
-		atcConfig.SkipCredentials,
+		atcConfig.CheckCredentials,
 	)
 	if err != nil {
 		return err

--- a/commands/internal/setpipelinehelpers/atc_config.go
+++ b/commands/internal/setpipelinehelpers/atc_config.go
@@ -24,6 +24,7 @@ type ATCConfig struct {
 	Team            concourse.Team
 	Target          string
 	SkipInteraction bool
+	SkipCredentials bool
 }
 
 func (atcConfig ATCConfig) ApplyConfigInteraction() bool {
@@ -129,6 +130,7 @@ func (atcConfig ATCConfig) Set(configPath atc.PathFlag, templateVariables []flag
 		atcConfig.PipelineName,
 		existingConfigVersion,
 		newConfig,
+		atcConfig.SkipCredentials,
 	)
 	if err != nil {
 		return err

--- a/commands/set_pipeline.go
+++ b/commands/set_pipeline.go
@@ -12,7 +12,7 @@ type SetPipelineCommand struct {
 	SkipInteractive  bool `short:"n"  long:"non-interactive"               description:"Skips interactions, uses default values"`
 	DisableAnsiColor bool `long:"no-color"               description:"Disable color output"`
 
-	SkipCredentials bool `short:"s"  long:"skip-creds"  description:"Skips validation of credential variables against credentials manager"`
+	CheckCredentials bool `long:"check-creds"  description:"Validate credential variables against credential manager"`
 
 	Pipeline flaghelpers.PipelineFlag `short:"p"  long:"pipeline"  required:"true"  description:"Pipeline to configure"`
 	Config   atc.PathFlag             `short:"c"  long:"config"    required:"true"  description:"Pipeline configuration file"`
@@ -49,11 +49,11 @@ func (command *SetPipelineCommand) Execute(args []string) error {
 	ansi.DisableColors(command.DisableAnsiColor)
 
 	atcConfig := setpipelinehelpers.ATCConfig{
-		Team:            target.Team(),
-		PipelineName:    pipelineName,
-		Target:          target.Client().URL(),
-		SkipInteraction: command.SkipInteractive,
-		SkipCredentials: command.SkipCredentials,
+		Team:             target.Team(),
+		PipelineName:     pipelineName,
+		Target:           target.Client().URL(),
+		SkipInteraction:  command.SkipInteractive,
+		CheckCredentials: command.CheckCredentials,
 	}
 
 	return atcConfig.Set(configPath, command.Var, command.YAMLVar, templateVariablesFiles)

--- a/commands/set_pipeline.go
+++ b/commands/set_pipeline.go
@@ -12,6 +12,8 @@ type SetPipelineCommand struct {
 	SkipInteractive  bool `short:"n"  long:"non-interactive"               description:"Skips interactions, uses default values"`
 	DisableAnsiColor bool `long:"no-color"               description:"Disable color output"`
 
+	SkipCredentials bool `short:"s"  long:"skip-creds"  description:"Skips validation of credential variables against credentials manager"`
+
 	Pipeline flaghelpers.PipelineFlag `short:"p"  long:"pipeline"  required:"true"  description:"Pipeline to configure"`
 	Config   atc.PathFlag             `short:"c"  long:"config"    required:"true"  description:"Pipeline configuration file"`
 
@@ -51,6 +53,7 @@ func (command *SetPipelineCommand) Execute(args []string) error {
 		PipelineName:    pipelineName,
 		Target:          target.Client().URL(),
 		SkipInteraction: command.SkipInteractive,
+		SkipCredentials: command.SkipCredentials,
 	}
 
 	return atcConfig.Set(configPath, command.Var, command.YAMLVar, templateVariablesFiles)


### PR DESCRIPTION
This add a ~~`--skipCreds`~~ `--checkCreds` parameter to `fly`, so that `fly` can opt to check server-side verification of credentials parameters.

This is for concourse/concourse#1920, and is intended to go with these other PRs:
concourse/atc#296
concourse/go-concourse#15