### PR TITLE
Make `fly set-pipeline` diff only print job names and diff'ed lines

### DIFF
--- a/commands/internal/setpipelinehelpers/diff.go
+++ b/commands/internal/setpipelinehelpers/diff.go
@@ -161,8 +161,6 @@ func renderDiff(to io.Writer, a, b string) {
 			fmt.Fprintf(indent, "%s %s\n", ansi.Color("+", "green"), ansi.Color(text, "green"))
 		case difflib.LeftOnly:
 			fmt.Fprintf(indent, "%s %s\n", ansi.Color("-", "red"), ansi.Color(text, "red"))
-		case difflib.Common:
-			fmt.Fprintf(to, "%s\n", text)
 		}
 	}
 }


### PR DESCRIPTION
The current behavior of `fly set-pipeline` is to show only jobs which
have a job and to print all lines of those changed jobs. When the jobs
themselves are very long, this can result in a lot of output which is
hard to scroll through.

Authored-by: Amil Khanzada <akhanzada@pivotal.io>

@jvigil-pivotal @tyacovone