### PR TITLE
Add fly clear-task-cache command

### DIFF
--- a/commands/clear_task_cache.go
+++ b/commands/clear_task_cache.go
@@ -43,17 +43,13 @@ func (command *ClearTaskCacheCommand) Execute([]string) error {
 		}
 	}
 
-	found, err := target.Team().ClearTaskCache(command.Job.PipelineName, command.Job.JobName, command.StepName, command.CachePath)
+	numRemoved, err := target.Team().ClearTaskCache(command.Job.PipelineName, command.Job.JobName, command.StepName, command.CachePath)
 
 	if err != nil {
+		fmt.Println(err.Error())
 		return err
-	}
-
-	if !found {
-		fmt.Printf("`%s`'s caches were already deleted or could not be found\n", command.Job.JobName)
 	} else {
-		fmt.Printf("`%s`'s caches were deleted\n", command.Job.JobName)
+		fmt.Printf("%d caches removed\n", numRemoved)
+		return nil
 	}
-
-	return nil
 }

--- a/commands/clear_task_cache.go
+++ b/commands/clear_task_cache.go
@@ -1,0 +1,59 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/concourse/fly/commands/internal/flaghelpers"
+	"github.com/concourse/fly/rc"
+	"github.com/vito/go-interact/interact"
+)
+
+type ClearTaskCacheCommand struct {
+	Job             flaghelpers.JobFlag `short:"j" long:"job"  required:"true"  description:"Job to clear cache from"`
+	StepName        string              `short:"s" long:"step"  required:"true" description:"Step name to clear cache from"`
+	CachePath       string              `short:"c" long:"cache-path"  default:"" description:"Cache directory to clear out"`
+	SkipInteractive bool                `short:"n"  long:"non-interactive"          description:"Destroy the task cache(s) without confirmation"`
+}
+
+func (command *ClearTaskCacheCommand) Execute([]string) error {
+	target, err := rc.LoadTarget(Fly.Target, Fly.Verbose)
+	if err != nil {
+		return err
+	}
+
+	err = target.Validate()
+	if err != nil {
+		return err
+	}
+
+	warningMsg := fmt.Sprintf("!!! this will remove the task cache(s) for `%s/%s`, task step `%s`",
+		command.Job.PipelineName, command.Job.JobName, command.StepName)
+	if len(command.CachePath) > 0 {
+		warningMsg += fmt.Sprintf(", at `%s`", command.CachePath)
+	}
+	warningMsg += "\n\n"
+	fmt.Printf(warningMsg)
+
+	confirm := command.SkipInteractive
+	if !confirm {
+		err := interact.NewInteraction("are you sure?").Resolve(&confirm)
+		if err != nil || !confirm {
+			fmt.Println("bailing out")
+			return err
+		}
+	}
+
+	found, err := target.Team().ClearTaskCache(command.Job.PipelineName, command.Job.JobName, command.StepName, command.CachePath)
+
+	if err != nil {
+		return err
+	}
+
+	if !found {
+		fmt.Printf("`%s`'s caches were already deleted or could not be found\n", command.Job.JobName)
+	} else {
+		fmt.Printf("`%s`'s caches were deleted\n", command.Job.JobName)
+	}
+
+	return nil
+}

--- a/commands/fly.go
+++ b/commands/fly.go
@@ -52,6 +52,8 @@ type FlyCommand struct {
 	PauseResource    PauseResourceCommand    `command:"pause-resource"    alias:"pr" description:"Pause a resource"`
 	UnpauseResource  UnpauseResourceCommand  `command:"unpause-resource"  alias:"ur" description:"Unpause a resource"`
 
+	ClearTaskCache ClearTaskCacheCommand `command:"clear-task-cache" alias:"ctc" description:"Clears cache from a task container"`
+
 	Builds     BuildsCommand     `command:"builds"      alias:"bs" description:"List builds data"`
 	AbortBuild AbortBuildCommand `command:"abort-build" alias:"ab" description:"Abort a build"`
 

--- a/commands/teams.go
+++ b/commands/teams.go
@@ -12,7 +12,7 @@ import (
 )
 
 type TeamsCommand struct {
-	Json bool `long:"json" description:"Print command result as JSON"`
+	Json    bool `long:"json" description:"Print command result as JSON"`
 	Details bool `short:"d" long:"details" description:"Print authentication configuration"`
 }
 
@@ -64,18 +64,18 @@ func (command *TeamsCommand) Execute([]string) error {
 			hasUsers := len(t.Auth["users"]) != 0
 			hasGroups := len(t.Auth["groups"]) != 0
 
-			if !hasUsers && !hasGroups{
+			if !hasUsers && !hasGroups {
 				usersCell.Contents = "all"
 				usersCell.Color = color.New(color.Faint)
 			} else if !hasUsers {
 				usersCell.Contents = "none"
 				usersCell.Color = color.New(color.Faint)
 			} else {
-				usersCell.Contents = strings.Join(t.Auth["users"],",")
+				usersCell.Contents = strings.Join(t.Auth["users"], ",")
 			}
 
 			if hasGroups {
-				groupsCell.Contents = strings.Join(t.Auth["groups"],",")
+				groupsCell.Contents = strings.Join(t.Auth["groups"], ",")
 			} else {
 				groupsCell.Contents = "none"
 				groupsCell.Color = color.New(color.Faint)

--- a/integration/clear_task_cache_test.go
+++ b/integration/clear_task_cache_test.go
@@ -1,0 +1,181 @@
+package integration_test
+
+import (
+	"fmt"
+	"io"
+	"os/exec"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+	"github.com/onsi/gomega/ghttp"
+)
+
+var _ = Describe("Fly CLI", func() {
+	Describe("clear-task-cache", func() {
+		var (
+			stdin io.Writer
+			args  []string
+			sess  *gexec.Session
+		)
+
+		BeforeEach(func() {
+			stdin = nil
+			args = []string{}
+		})
+
+		JustBeforeEach(func() {
+			var err error
+
+			flyCmd := exec.Command(flyPath, append([]string{"-t", targetName, "clear-task-cache"}, args...)...)
+			stdin, err = flyCmd.StdinPipe()
+			Expect(err).NotTo(HaveOccurred())
+
+			sess, err = gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("when a job is not specified", func() {
+			It("asks the user to specify a job", func() {
+				flyCmd := exec.Command(flyPath, "-t", targetName, "clear-task-cache", "-s", "some-task-step")
+
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(sess).Should(gexec.Exit(1))
+
+				Expect(sess.Err).To(gbytes.Say("error: the required flag `" + osFlag("j", "job") + "' was not specified"))
+			})
+		})
+
+		Context("when a step is not specified", func() {
+			It("asks the user to specify a step", func() {
+				flyCmd := exec.Command(flyPath, "-t", targetName, "clear-task-cache", "-j", "some-pipeline/some-job")
+
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(sess).Should(gexec.Exit(1))
+
+				Expect(sess.Err).To(gbytes.Say("error: the required flag `" + osFlag("s", "step") + "' was not specified"))
+			})
+		})
+
+		Context("when specifying a job without a pipeline name", func() {
+			It("asks the user to specify a pipeline name", func() {
+				flyCmd := exec.Command(flyPath, "-t", targetName, "clear-task-cache", "-s", "some-task-step", "-j", "myjob")
+
+				sess, err := gexec.Start(flyCmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				<-sess.Exited
+				Expect(sess.ExitCode()).To(Equal(1))
+
+				Expect(sess.Err).To(gbytes.Say("error: invalid argument for flag " + "`" + "-j, --job'"))
+				Expect(sess.Err).To(gbytes.Say(`argument format should be <pipeline>/<job>`))
+			})
+		})
+
+		Context("when a job and step name are specified", func() {
+			BeforeEach(func() {
+				args = append(args, "-j", "some-pipeline/some-job", "-s", "some-step-name")
+			})
+
+			yes := func() {
+				Eventually(sess).Should(gbytes.Say(`are you sure\? \[yN\]: `))
+				fmt.Fprintf(stdin, "y\n")
+			}
+
+			no := func() {
+				Eventually(sess).Should(gbytes.Say(`are you sure\? \[yN\]: `))
+				fmt.Fprintf(stdin, "n\n")
+			}
+
+			It("warns that it's about to do bad things", func() {
+				Eventually(sess).Should(gbytes.Say("!!! this will remove the task cache\\(s\\) for `some-pipeline/some-job`, task step `some-step-name`"))
+			})
+
+			It("bails out if the user says no", func() {
+				no()
+				Eventually(sess).Should(gbytes.Say(`bailing out`))
+				Eventually(sess).Should(gexec.Exit(0))
+			})
+
+			Context("when the task step exists", func() {
+				BeforeEach(func() {
+					atcServer.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("DELETE", "/api/v1/teams/main/pipelines/some-pipeline/jobs/some-job/tasks/some-step-name/cache"),
+							ghttp.RespondWith(204, ""),
+						),
+					)
+				})
+
+				It("succeeds if the user says yes", func() {
+					yes()
+					Eventually(sess).Should(gbytes.Say("`some-job`'s caches were deleted"))
+					Eventually(sess).Should(gexec.Exit(0))
+				})
+
+				Context("when run noninteractively", func() {
+					BeforeEach(func() {
+						args = append(args, "-n")
+					})
+
+					It("destroys the task step cache without confirming", func() {
+						Eventually(sess).Should(gbytes.Say("`some-job`'s caches were deleted"))
+						Eventually(sess).Should(gexec.Exit(0))
+					})
+				})
+
+				Context("and a cache path is specified", func() {
+					BeforeEach(func() {
+						args = append(args, "-c", "path/to/cache")
+					})
+
+					It("succeeds if the user says yes", func() {
+						yes()
+						Eventually(sess).Should(gbytes.Say("`some-job`'s caches were deleted"))
+						Eventually(sess).Should(gexec.Exit(0))
+					})
+
+				})
+			})
+
+			Context("and the task step does not exist", func() {
+				BeforeEach(func() {
+					atcServer.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("DELETE", "/api/v1/teams/main/pipelines/some-pipeline/jobs/some-job/tasks/some-step-name/cache"),
+							ghttp.RespondWith(404, ""),
+						),
+					)
+				})
+
+				It("writes that it did not exist and exits successfully", func() {
+					yes()
+					Eventually(sess).Should(gbytes.Say("`some-job`'s caches were already deleted or could not be found"))
+					Eventually(sess).Should(gexec.Exit(0))
+				})
+			})
+
+			Context("and the api returns an unexpected status code", func() {
+				BeforeEach(func() {
+					atcServer.AppendHandlers(
+						ghttp.CombineHandlers(
+							ghttp.VerifyRequest("DELETE", "/api/v1/teams/main/pipelines/some-pipeline/jobs/some-job/tasks/some-step-name/cache"),
+							ghttp.RespondWith(402, ""),
+						),
+					)
+				})
+
+				It("writes an error message to stderr", func() {
+					yes()
+					Eventually(sess.Err).Should(gbytes.Say("Unexpected Response"))
+					Eventually(sess).Should(gexec.Exit(1))
+				})
+			})
+		})
+	})
+})

--- a/integration/clear_task_cache_test.go
+++ b/integration/clear_task_cache_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Fly CLI", func() {
 					atcServer.AppendHandlers(
 						ghttp.CombineHandlers(
 							ghttp.VerifyRequest("DELETE", "/api/v1/teams/main/pipelines/some-pipeline/jobs/some-job/tasks/some-step-name/cache"),
-							ghttp.RespondWithJSONEncoded(http.StatusOK, atc.ClearTaskCacheResponse{NumCacheRemoved: 1}),
+							ghttp.RespondWithJSONEncoded(http.StatusOK, atc.ClearTaskCacheResponse{CachesRemoved: 1}),
 						),
 					)
 				})
@@ -150,7 +150,7 @@ var _ = Describe("Fly CLI", func() {
 					atcServer.AppendHandlers(
 						ghttp.CombineHandlers(
 							ghttp.VerifyRequest("DELETE", "/api/v1/teams/main/pipelines/some-pipeline/jobs/some-job/tasks/some-step-name/cache"),
-							ghttp.RespondWithJSONEncoded(http.StatusOK, atc.ClearTaskCacheResponse{NumCacheRemoved: 0}),
+							ghttp.RespondWithJSONEncoded(http.StatusOK, atc.ClearTaskCacheResponse{CachesRemoved: 0}),
 						),
 					)
 				})

--- a/integration/teams_test.go
+++ b/integration/teams_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Fly CLI", func() {
 								Name: "main",
 								Auth: map[string][]string{
 									"groups": []string{},
-									"users": []string{},
+									"users":  []string{},
 								},
 							},
 							{
@@ -42,7 +42,7 @@ var _ = Describe("Fly CLI", func() {
 								Name: "a-team",
 								Auth: map[string][]string{
 									"groups": []string{"github:github-org"},
-									"users": []string{},
+									"users":  []string{},
 								},
 							},
 							{
@@ -50,15 +50,15 @@ var _ = Describe("Fly CLI", func() {
 								Name: "b-team",
 								Auth: map[string][]string{
 									"groups": []string{},
-									"users": []string{"github:github-user"},
+									"users":  []string{"github:github-user"},
 								},
 							},
 							{
 								ID:   4,
 								Name: "c-team",
 								Auth: map[string][]string{
-									"users": []string{"github:github-user"},
-									"groups":[]string{"github:github-org"},
+									"users":  []string{"github:github-user"},
+									"groups": []string{"github:github-org"},
 								},
 							},
 						}),


### PR DESCRIPTION
Adds a `clear-task-cache` command to `fly` as described in concourse/concourse#1817.

Intended to go with:
concourse/atc#298
concourse/go-concourse#16