### PR TITLE
Change link in readme to use valid Concourse documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A command line interface that runs a build in a container with [ATC](https://git
 
 [The documentation](https://concourse-ci.org/fly.html) is hosted together with Concourse's docs.
 
-A good place to start learning about Concourse is [its documentation](https://concourse-ci.org/docs.html)
+A good place to start learning about Concourse is [its documentation](https://concourse-ci.org/index.html)
 or its [BOSH release](https://github.com/concourse/concourse).
 
 ## Reporting Issues and Requesting Features


### PR DESCRIPTION
It is currently pointing to https://concourse-ci.org/docs.html which is not valid. So changed it to use /index.html